### PR TITLE
[FIXED] Build libCacheSim was missing install

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ mkdir _build
 cd _build
 cmake ..
 make -j
+[sudo] make install
 ```
 
 #### Linking with libCacheSim


### PR DESCRIPTION
While building libCacheSim, the install command was missing. Added it to README.md