### PR TITLE
Fix test.c and README gcc command issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ cache->cache_free(cache);
 ```
 save this to `test.c` and compile with 
 ```
-gcc $(pkg-config --cflags --libs libCacheSim glib-2.0) -lm -ldl test.c -o test
+gcc $(pkg-config --cflags --libs libCacheSim glib-2.0) -lm -ldl test.c -o test.out
 ```
 
 if you get `error while loading shared libraries`, run `sudo ldconfig`

--- a/test.c
+++ b/test.c
@@ -1,29 +1,32 @@
-
-
 #include <libCacheSim.h>
 
-/* open trace, see quickstart.md for opening csv and binary trace */
-reader_t *reader = open_trace("data/trace.vscsi", VSCSI_TRACE, OBJ_ID_NUM, NULL);
+int main(int argc, char *argv[])
+{
+  /* open trace, see quickstart.md for opening csv and binary trace */
+  reader_t *reader = open_trace("data/trace.vscsi", VSCSI_TRACE, OBJ_ID_NUM, NULL);
 
-/* craete a container for reading from trace */
-request_t *req = new_request();
+  /* craete a container for reading from trace */
+  request_t *req = new_request();
 
-/* create a LRU cache */
-common_cache_params_t cc_params = {.cache_size=1024*1024U};
-cache_t *cache = create_cache("LRU", cc_params, NULL);
+  /* create a LRU cache */
+  common_cache_params_t cc_params = {.cache_size=1024*1024U};
+  cache_t *cache = create_cache("LRU", cc_params, NULL);
 
-/* counters */
-uint64_t req_byte = 0, miss_byte = 0;
+  /* counters */
+  uint64_t req_byte = 0, miss_byte = 0;
 
-/* loop through the trace */
-while (read_one_req(reader, req) == 0) {
-if (cache->get(cache, req) == cache_ck_miss) {
-miss_byte += req->obj_size;
+  /* loop through the trace */
+  while (read_one_req(reader, req) == 0) {
+  if (cache->get(cache, req) == cache_ck_miss) {
+  miss_byte += req->obj_size;
+  }
+  req_byte += req->obj_size;
+  }
+
+  /* cleaning */
+  close_trace(reader);
+  free_request(req);
+  cache->cache_free(cache);
+
+  return 0;
 }
-req_byte += req->obj_size;
-}
-
-/* cleaning */
-close_trace(reader);
-free_request(req);
-cache->cache_free(cache);


### PR DESCRIPTION
This pull request aims to resolve the compilation error for `test.c`. It made simple changes to add main function and return in `test.c`, and gcc command in the README is modified to avoid output filename conflict with the existing test directory, i.e., change output from `test` to `test.out`.

Associated Issue: #2 