### PR TITLE
fix algorithm name compatibility

### DIFF
--- a/libCacheSim/bin/cachesim/cache_init.h
+++ b/libCacheSim/bin/cachesim/cache_init.h
@@ -121,7 +121,7 @@ static inline cache_t *create_cache(const char *trace_path,
     cache = Sieve_Belady_init(cc_params, eviction_params);
   } else if (strcasecmp(eviction_algo, "s3lru") == 0) {
     cache = S3LRU_init(cc_params, eviction_params);
-  } else if (strcasecmp(eviction_algo, "s3fifo") == 0) {
+  } else if (strcasecmp(eviction_algo, "s3fifo") == 0 || strcasecmp(eviction_algo, "s3-fifo") == 0) {
     cache = S3FIFO_init(cc_params, eviction_params);
   } else if (strcasecmp(eviction_algo, "s3fifod") == 0) {
     cache = S3FIFOd_init(cc_params, eviction_params);


### PR DESCRIPTION
This change allows the user to use "S3-FIFO" as the algorithm name in cachesim