### PR TITLE
feat(prefetch): add OBL

### DIFF
--- a/libCacheSim/bin/cachesim/cli_parser.c
+++ b/libCacheSim/bin/cachesim/cli_parser.c
@@ -72,7 +72,7 @@ static struct argp_option options[] = {
     {"admission-params", OPTION_ADMISSION_PARAMS, "\"prob=0.8\"", 0,
      "params for admission algorithm", 4},
     {"prefetch", OPTION_PREFETCH_ALGO, "Mithril", 0,
-     "Prefetching algorithm: Mithril", 4},
+     "Prefetching algorithm: Mithril/OBL/PG/AMP", 4},
     {"prefetch-params", OPTION_PREFETCH_PARAMS, "\"block-size=65536\"", 0,
      "optional params for each prefetching algorithm, e.g., block-size=65536",
      4},

--- a/libCacheSim/cache/prefetch/CMakeLists.txt
+++ b/libCacheSim/cache/prefetch/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(prefetchC Mithril.c)
+add_library(prefetchC Mithril.c OBL.c)
 
 add_library(prefetch INTERFACE)
 target_link_libraries(prefetch INTERFACE prefetchC)

--- a/libCacheSim/cache/prefetch/OBL.c
+++ b/libCacheSim/cache/prefetch/OBL.c
@@ -1,0 +1,178 @@
+//
+//  an OBL module that supports sequential prefetching for block storage. Each
+//  object (logical block address) should be uniform in size.
+//
+//
+//  OBL.c
+//  libCacheSim
+//
+//  Created by Zhelong on 24/1/29.
+//  Copyright © 2024 Zhelong. All rights reserved.
+//
+#include "../../include/libCacheSim/prefetchAlgo/OBL.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <sys/types.h>
+
+#include "../../include/libCacheSim/prefetchAlgo.h"
+// #define DEBUG
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ***********************************************************************
+// ****                                                               ****
+// ****               helper function declarations                    ****
+// ****                                                               ****
+// ***********************************************************************
+
+const char *OBL_default_params(void) { return "block-size=512, sequential-confidence-k=4"; }
+
+static void set_OBL_default_init_params(OBL_init_params_t *init_params) {
+  init_params->block_size = 512;
+  init_params->sequential_confidence_k = 4;
+}
+
+static void OBL_parse_init_params(const char *cache_specific_params, OBL_init_params_t *init_params) {
+  char *params_str = strdup(cache_specific_params);
+
+  while (params_str != NULL && params_str[0] != '\0') {
+    char *key = strsep((char **)&params_str, "=");
+    char *value = strsep((char **)&params_str, ",");
+    while (params_str != NULL && *params_str == ' ') {
+      params_str++;
+    }
+    if (strcasecmp(key, "block-size") == 0) {
+      init_params->block_size = atoi(value);
+    } else if (strcasecmp(key, "sequential-confidence-k") == 0) {
+      init_params->sequential_confidence_k = atoi(value);
+    } else {
+      ERROR("OBL does not have parameter %s\n", key);
+      printf("default params: %s\n", OBL_default_params());
+      exit(1);
+    }
+  }
+}
+
+static void set_OBL_params(OBL_params_t *OBL_params, OBL_init_params_t *init_params, uint64_t cache_size) {
+  OBL_params->block_size = init_params->block_size;
+  OBL_params->sequential_confidence_k = init_params->sequential_confidence_k;
+  OBL_params->do_prefetch = false;
+  if (OBL_params->sequential_confidence_k <= 0) {
+    printf("sequential_confidence_k should be positive\n");
+    exit(1);
+  }
+  OBL_params->prev_access_block = (obj_id_t *)malloc(OBL_params->sequential_confidence_k * sizeof(obj_id_t));
+  for (int i = 0; i < OBL_params->sequential_confidence_k; i++) {
+    OBL_params->prev_access_block[i] = UINT64_MAX;
+  }
+  OBL_params->curr_idx = 0;
+}
+
+/**************************************************************************
+ **                      prefetcher interfaces
+ **
+ ** create, free, clone, handle_find, handle_insert, handle_evict, prefetch
+ **************************************************************************/
+prefetcher_t *create_OBL_prefetcher(const char *init_params, uint64_t cache_size);
+/**
+ check if the previous access is sequential. If true, set do_prefetch to true.
+
+@param cache the cache struct
+@param req the request containing the request
+@return
+*/
+static void OBL_handle_find(cache_t *cache, const request_t *req, bool hit) {
+  OBL_params_t *OBL_params = (OBL_params_t *)(cache->prefetcher->params);
+  int32_t sequential_confidence_k = OBL_params->sequential_confidence_k;
+
+  // assert(req->obj_size == OBL_params->block_size);
+  bool flag = true;
+  for (int i = 0; i < sequential_confidence_k; i++) {
+    if (OBL_params->prev_access_block[(OBL_params->curr_idx + 1 + i) % sequential_confidence_k] !=
+        req->obj_id - sequential_confidence_k + i) {
+      flag = false;
+      break;
+    }
+  }
+  OBL_params->do_prefetch = flag;
+  OBL_params->curr_idx = (OBL_params->curr_idx + 1) % sequential_confidence_k;
+  OBL_params->prev_access_block[OBL_params->curr_idx] = req->obj_id;
+}
+
+/**
+ prefetch next block if the previous access is sequential
+
+ @param cache the cache struct
+ @param req the request containing the request
+ @return
+ */
+void OBL_prefetch(cache_t *cache, const request_t *req) {
+  OBL_params_t *OBL_params = (OBL_params_t *)(cache->prefetcher->params);
+
+  if (OBL_params->do_prefetch) {
+    OBL_params->do_prefetch = false;
+    request_t *new_req = new_request();
+    new_req->obj_size = OBL_params->block_size;
+    new_req->obj_id = req->obj_id + 1;
+    if (cache->find(cache, new_req, false)) {
+      free_request(new_req);
+      return;
+    }
+    while (cache->get_occupied_byte(cache) + OBL_params->block_size > cache->cache_size) {
+      cache->evict(cache, req);
+    }
+    cache->insert(cache, new_req);
+    free_request(new_req);
+  }
+}
+
+void free_OBL_prefetcher(prefetcher_t *prefetcher) {
+  OBL_params_t *OBL_params = (OBL_params_t *)prefetcher->params;
+  free(OBL_params->prev_access_block);
+
+  my_free(sizeof(OBL_params_t), OBL_params);
+  if (prefetcher->init_params) {
+    free(prefetcher->init_params);
+  }
+  my_free(sizeof(prefetcher_t), prefetcher);
+}
+
+prefetcher_t *clone_OBL_prefetcher(prefetcher_t *prefetcher, uint64_t cache_size) {
+  return create_OBL_prefetcher(prefetcher->init_params, cache_size);
+}
+
+prefetcher_t *create_OBL_prefetcher(const char *init_params, uint64_t cache_size) {
+  OBL_init_params_t *OBL_init_params = my_malloc(OBL_init_params_t);
+  memset(OBL_init_params, 0, sizeof(OBL_init_params_t));
+
+  set_OBL_default_init_params(OBL_init_params);
+  if (init_params != NULL) {
+    OBL_parse_init_params(init_params, OBL_init_params);
+  }
+
+  OBL_params_t *OBL_params = my_malloc(OBL_params_t);
+  set_OBL_params(OBL_params, OBL_init_params, cache_size);
+
+  prefetcher_t *prefetcher = (prefetcher_t *)my_malloc(prefetcher_t);
+  memset(prefetcher, 0, sizeof(prefetcher_t));
+  prefetcher->params = OBL_params;
+  prefetcher->prefetch = OBL_prefetch;
+  prefetcher->handle_find = OBL_handle_find;
+  prefetcher->handle_insert = NULL;
+  prefetcher->handle_evict = NULL;
+  prefetcher->free = free_OBL_prefetcher;
+  prefetcher->clone = clone_OBL_prefetcher;
+  if (init_params) {
+    prefetcher->init_params = strdup(init_params);
+  }
+
+  my_free(sizeof(OBL_init_params_t), OBL_init_params);
+  return prefetcher;
+}

--- a/libCacheSim/include/libCacheSim/prefetchAlgo.h
+++ b/libCacheSim/include/libCacheSim/prefetchAlgo.h
@@ -1,6 +1,8 @@
 #ifndef PREFETCHINGALGO_H
 #define PREFETCHINGALGO_H
 
+#include <strings.h>
+
 #include "cache.h"
 #include "request.h"
 
@@ -13,6 +15,7 @@ typedef struct prefetcher *(*prefetcher_create_func_ptr)(const char *);
 typedef void (*prefetcher_prefetch_func_ptr)(cache_t *, const request_t *);
 typedef void (*prefetcher_handle_find_func_ptr)(cache_t *, const request_t *,
                                                 bool);
+typedef void (*prefetcher_handle_insert_func_ptr)(cache_t *, const request_t *);
 typedef void (*prefetcher_handle_evict_func_ptr)(cache_t *, const request_t *);
 typedef void (*prefetcher_free_func_ptr)(struct prefetcher *);
 typedef struct prefetcher *(*prefetcher_clone_func_ptr)(struct prefetcher *,
@@ -23,6 +26,7 @@ typedef struct prefetcher {
   void *init_params;
   prefetcher_prefetch_func_ptr prefetch;
   prefetcher_handle_find_func_ptr handle_find;
+  prefetcher_handle_insert_func_ptr handle_insert;
   prefetcher_handle_evict_func_ptr handle_evict;
   prefetcher_free_func_ptr free;
   prefetcher_clone_func_ptr clone;
@@ -30,6 +34,7 @@ typedef struct prefetcher {
 
 prefetcher_t *create_Mithril_prefetcher(const char *init_paramsm,
                                         uint64_t cache_size);
+prefetcher_t *create_OBL_prefetcher(const char *init_paramsm, uint64_t cache_size);
 
 static inline prefetcher_t *create_prefetcher(const char *prefetching_algo,
                                               const char *prefetching_params,
@@ -37,6 +42,8 @@ static inline prefetcher_t *create_prefetcher(const char *prefetching_algo,
   prefetcher_t *prefetcher = NULL;
   if (strcasecmp(prefetching_algo, "Mithril") == 0) {
     prefetcher = create_Mithril_prefetcher(prefetching_params, cache_size);
+  } else if (strcasecmp(prefetching_algo, "OBL") == 0) {
+    prefetcher = create_OBL_prefetcher(prefetching_params, cache_size);
   } else {
     ERROR("prefetching algo %s not supported\n", prefetching_algo);
   }

--- a/libCacheSim/include/libCacheSim/prefetchAlgo/OBL.h
+++ b/libCacheSim/include/libCacheSim/prefetchAlgo/OBL.h
@@ -1,0 +1,29 @@
+#ifndef OBL_H
+#define OBL_H
+#include <assert.h>
+#include <glib.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include "../cache.h"
+
+typedef struct OBL_params {
+  int32_t block_size;
+  bool do_prefetch;
+
+  uint32_t curr_idx;                // current index in the prev_access_block
+  int32_t sequential_confidence_k;  // number of prev sequential accesses to be
+                                    // considered as a sequential access
+  obj_id_t* prev_access_block;      // prev k accessed
+} OBL_params_t;
+
+typedef struct OBL_init_params {
+  int32_t block_size;
+  int32_t sequential_confidence_k;
+} OBL_init_params_t;
+
+#define DO_PREFETCH(id)
+
+#endif

--- a/test/common.h
+++ b/test/common.h
@@ -258,6 +258,9 @@ static cache_t *create_test_cache(const char *alg_name,
     cache = LRU_init(cc_params, NULL);
     cache->prefetcher =
         create_prefetcher("Mithril", NULL, cc_params.cache_size);
+  } else if (strcasecmp(alg_name, "OBL") == 0) {
+    cache = LRU_init(cc_params, NULL);
+    cache->prefetcher = create_prefetcher("OBL", NULL, cc_params.cache_size);
   } else {
     printf("cannot recognize algorithm %s\n", alg_name);
     exit(1);

--- a/test/test_prefetchAlgo.c
+++ b/test/test_prefetchAlgo.c
@@ -65,6 +65,23 @@ static void test_Mithril(gconstpointer user_data) {
   my_free(sizeof(cache_stat_t), res);
 }
 
+static void test_OBL(gconstpointer user_data) {
+  uint64_t miss_cnt_true[] = {92139, 88548, 82337, 80487, 71259, 70869, 70737, 70469};
+  uint64_t miss_byte_true[] = {4213140480, 4060079616, 3776877568, 3659406848,
+                               3099764736, 3076965888, 3074241024, 3060499968};
+
+  reader_t *reader = (reader_t *)user_data;
+  common_cache_params_t cc_params = {.cache_size = CACHE_SIZE, .hashpower = 20, .default_ttl = DEFAULT_TTL};
+  cache_t *cache = create_test_cache("OBL", cc_params, reader, NULL);
+  g_assert_true(cache != NULL);
+  cache_stat_t *res = simulate_at_multi_sizes_with_step_size(reader, cache, STEP_SIZE, NULL, 0, 0, _n_cores());
+
+  print_results(cache, res);
+  _verify_profiler_results(res, CACHE_SIZE / STEP_SIZE, g_req_cnt_true, miss_cnt_true, g_req_byte_true, miss_byte_true);
+  cache->cache_free(cache);
+  my_free(sizeof(cache_stat_t), res);
+}
+
 int main(int argc, char *argv[]) {
   g_test_init(&argc, &argv, NULL);
   srand(0);  // for reproducibility
@@ -80,6 +97,7 @@ int main(int argc, char *argv[]) {
   reader = setup_oracleGeneralBin_reader();
   // reader = setup_vscsi_reader_with_ignored_obj_size();
   g_test_add_data_func("/libCacheSim/cacheAlgo_Mithril", reader, test_Mithril);
+  g_test_add_data_func("/libCacheSim/cacheAlgo_OBL", reader, test_OBL);
 
   return g_test_run();
 }


### PR DESCRIPTION
Hello, @1a1a11a, happy CNY!

I implemented the [OBL](https://dl.acm.org/doi/10.1145/356887.356892) prefetching algorithm for libcachesim. 

It is a sequential prefetching algorithm, which means maybe `obj_id` should be the logical block address. But I still use the default cache trace as a test.

The reconstruction of PG is on the way!