### PR TITLE
Reformat build cmd in docs and fix a type hint in plot code

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ cachesim supports the following algorithms:
 ### One-line install
 We provide some scripts for quick installation of libCacheSim. 
 ```bash
-cd scripts && bash install_dependency.sh && bash install_libcachesim.sh;
+cd scripts && bash install_dependency.sh && bash install_libcachesim.sh
 ```
 If this does not work, please 
 1. let us know what system you are using and what error you get
@@ -104,13 +104,13 @@ Please see [install.md](/doc/install.md) for instructions on how to install the 
 <!-- TOC --><a name="build-libcachesim"></a>
 ### Build libCacheSim
 cmake recommends **out-of-source build**, so we do it in a new directory:
-```
+```bash
 git clone https://github.com/1a1a11a/libCacheSim
-pushd libCachesim;
-mkdir _build && cd _build;
-cmake .. && make -j;
-[sudo] make install;
-popd;
+pushd libCacheSim
+mkdir _build && cd _build
+cmake .. && make -j
+[sudo] make install
+popd
 ```
 ---
 
@@ -164,7 +164,7 @@ You can plot miss ratios of different algorithms and sizes, and plot the miss ra
 
 ```bash
 # plot miss ratio over size
-cd scripts;
+cd scripts
 python3 plot_mrc_size.py --tracepath ../data/twitter_cluster52.csv --trace-format csv --trace-format-params="time-col=1,obj-id-col=2,obj-size-col=3,delimiter=," --algos=fifo,lru,lecar,s3fifo --sizes=0.001,0.002,0.005,0.01,0.02,0.05,0.1,0.2,0.3,0.4
 
 # plot miss ratio over time

--- a/doc/install.md
+++ b/doc/install.md
@@ -8,46 +8,46 @@ libCacheSim uses [camke](https://cmake.org/) build system and has a few dependen
 
 ### Install dependency on Ubuntu
 #### Install glib, tcmalloc and cmake
-```
+```bash
 sudo apt install libglib2.0-dev libgoogle-perftools-dev cmake
 ```
 
 #### Install zstd
 zstd must be installed from source
-```
-wget https://github.com/facebook/zstd/releases/download/v1.5.0/zstd-1.5.0.tar.gz;
-tar xvf zstd-1.5.0.tar.gz;
-pushd zstd-1.5.0/build/cmake/;
-mkdir _build && cd _build/;
-cmake .. && make -j;
-sudo make install;
-popd;
+```bash
+wget https://github.com/facebook/zstd/releases/download/v1.5.0/zstd-1.5.0.tar.gz
+tar xvf zstd-1.5.0.tar.gz
+pushd zstd-1.5.0/build/cmake/
+mkdir _build && cd _build/
+cmake .. && make -j
+sudo make install
+popd
 ```
 
 #### Install XGBoost [Optional]
-```
-git clone --recursive https://github.com/dmlc/xgboost;
-pushd xgboost;
-mkdir _build && cd _build;
-cmake .. && make -j; 
-sudo make install;
-popd;
+```bash
+git clone --recursive https://github.com/dmlc/xgboost
+pushd xgboost
+mkdir _build && cd _build
+cmake .. && make -j
+sudo make install
+popd
 ```
 
 #### Install LightGBM [Optional]
-```
-git clone --recursive https://github.com/microsoft/LightGBM;
-pushd LightGBM;
-mkdir _build && cd _build;
-cmake .. && make -j;
+```bash
+git clone --recursive https://github.com/microsoft/LightGBM
+pushd LightGBM
+mkdir _build && cd _build
+cmake .. && make -j
 sudo make install
-popd;
+popd
 ```
 
 
 ### Install dependency on Mac
 using [homebrew](https://brew.sh/) as an example
-```
+```bash
 brew install cmake glib google-perftools
 ```
 And you need to install the rest of the dependencies manually.

--- a/scripts/utils/str_utils.py
+++ b/scripts/utils/str_utils.py
@@ -26,7 +26,7 @@ def conv_size_str_to_int(size_str: str) -> int:
     return cache_size
 
 
-def find_unit_of_cache_size(cache_size: int) -> tuple[int, str]:
+def find_unit_of_cache_size(cache_size: int) -> Tuple[int, str]:
     """convert a cache size in int (byte) to a size with unit"""
 
     size_unit, size_unit_str = 1, "B"


### PR DESCRIPTION
On case-sensitive file systems such as `ext4`, `pushd libCachesim` will fail as the folder is named `libCacheSim`.


