### PR TITLE
Fix several memory leaks

### DIFF
--- a/libCacheSim/bin/cachesim/main.c
+++ b/libCacheSim/bin/cachesim/main.c
@@ -72,6 +72,9 @@ int main(int argc, char **argv) {
   }
   fclose(output_file);
 
+  if (args.n_cache_size * args.n_eviction_algo > 0)
+    my_free(sizeof(cache_stat_t) * args.n_cache_size * args.n_eviction_algo, result);
+
   free_arg(&args);
 
   return 0;

--- a/libCacheSim/bin/cachesim/sim.c
+++ b/libCacheSim/bin/cachesim/sim.c
@@ -93,6 +93,8 @@ void simulate(reader_t *reader, cache_t *cache, int report_interval,
   }
 
 #endif
+  free_request(req);
+  cache->cache_free(cache);
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Avoid memory leaks when `args.n_cache_size * args.n_eviction_algo == 1`.