### PR TITLE
Unify result print format to be ignore-obj-size-aware

### DIFF
--- a/libCacheSim/bin/cachesim/internal.h
+++ b/libCacheSim/bin/cachesim/internal.h
@@ -57,7 +57,7 @@ void parse_cmd(int argc, char *argv[], struct arguments *args);
 void free_arg(struct arguments *args);
 
 void simulate(reader_t *reader, cache_t *cache, int report_interval,
-              int warmup_sec, char *ofilepath);
+              int warmup_sec, char *ofilepath, bool ignore_obj_size);
 
 void print_parsed_args(struct arguments *args);
 

--- a/libCacheSim/bin/cachesim/main.c
+++ b/libCacheSim/bin/cachesim/main.c
@@ -22,7 +22,7 @@ int main(int argc, char **argv) {
 
   if (args.n_cache_size * args.n_eviction_algo == 1) {
     simulate(args.reader, args.caches[0], args.report_interval, args.warmup_sec,
-             args.ofilepath);
+             args.ofilepath, args.ignore_obj_size);
 
     free_arg(&args);
     return 0;
@@ -54,6 +54,8 @@ int main(int argc, char **argv) {
     } else if (args.cache_sizes[0] > KiB) {
       size_unit = KiB;
       size_unit_str = "KiB";
+    } else {
+      size_unit_str = "B";
     }
   }
 

--- a/libCacheSim/bin/cachesim/sim.c
+++ b/libCacheSim/bin/cachesim/sim.c
@@ -11,7 +11,7 @@ extern "C" {
 #endif
 
 void simulate(reader_t *reader, cache_t *cache, int report_interval,
-              int warmup_sec, char *ofilepath) {
+              int warmup_sec, char *ofilepath, bool ignore_obj_size) {
   /* random seed */
   srand(time(NULL));
   set_rand_seed(rand());
@@ -66,15 +66,25 @@ void simulate(reader_t *reader, cache_t *cache, int report_interval,
 
   char output_str[1024];
   char size_str[8];
-  convert_size_to_str(cache->cache_size, size_str);
+  if (!ignore_obj_size)
+    convert_size_to_str(cache->cache_size, size_str);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-truncation"
-  snprintf(output_str, 1024,
-           "%s %s cache size %8s, %16lu req, miss ratio %.4lf, throughput "
-           "%.2lf MQPS\n",
-           reader->trace_path, cache->cache_name, size_str,
-           (unsigned long)req_cnt, (double)miss_cnt / (double)req_cnt,
-           (double)req_cnt / 1000000.0 / runtime);
+  if (!ignore_obj_size) {
+    snprintf(output_str, 1024,
+            "%s %s cache size %8s, %16lu req, miss ratio %.4lf, throughput "
+            "%.2lf MQPS\n",
+            reader->trace_path, cache->cache_name, size_str,
+            (unsigned long)req_cnt, (double)miss_cnt / (double)req_cnt,
+            (double)req_cnt / 1000000.0 / runtime);
+  } else {
+    snprintf(output_str, 1024,
+            "%s %s cache size %8ld, %16lu req, miss ratio %.4lf, throughput "
+            "%.2lf MQPS\n",
+            reader->trace_path, cache->cache_name, cache->cache_size,
+            (unsigned long)req_cnt, (double)miss_cnt / (double)req_cnt,
+            (double)req_cnt / 1000000.0 / runtime);
+  }
 
 #pragma GCC diagnostic pop
   printf("%s", output_str);

--- a/libCacheSim/traceAnalyzer/utils/include/utilsStr.h
+++ b/libCacheSim/traceAnalyzer/utils/include/utilsStr.h
@@ -29,7 +29,7 @@ static inline void convert_size_to_str(long long size, char *str) {
     } else if (size >= KiB) {
         sprintf(str, "%.0lf KiB", (double) size / KiB);
     } else {
-        sprintf(str, "%lld", size);
+        sprintf(str, "%lld B", size);
     }
 }
 

--- a/libCacheSim/utils/mystr.c
+++ b/libCacheSim/utils/mystr.c
@@ -27,7 +27,7 @@ void convert_size_to_str(unsigned long long size, char *str) {
   } else if (size >= KiB) {
     sprintf(str, "%.0lfKiB", (double)size / KiB);
   } else {
-    sprintf(str, "%lld", size);
+    sprintf(str, "%lldB", size);
   }
 }
 


### PR DESCRIPTION
When print simulation results (except for [info]), unify the format with the logic as follows:
if `ignore-obj-size=False`, cache size is xxB/KiB/MiB ... (align with [common.py](https://github.com/1a1a11a/libCacheSim/blob/develop/scripts/pyutils/common.py#L116-L126))
else,  cache size is a pure number (the number of objects).

```bash
# multi sim is ignore-obj-size-aware in the print format, however, single is not
$ ../_build/bin/cachesim ../data/cloudPhysicsIO.vscsi vscsi s3fifo 0.1 --ignore-obj-size 0
../data/cloudPhysicsIO.vscsi S3FIFO-0.1000-2 cache size   194MiB,           113872 req, miss ratio 0.7273, throughput 5.87 MQPS
$ ../_build/bin/cachesim ../data/cloudPhysicsIO.vscsi vscsi s3fifo 0.1 --ignore-obj-size 1
../data/cloudPhysicsIO.vscsi S3FIFO-0.1000-2 cache size     5KiB,           113872 req, miss ratio 0.7525, throughput 5.87 MQPS
```
besides, when the size is less than 1KiB, no unit will also be confusing so we can add a unit "B" (Byte) for the case `--ignore-obj-size 0`.

```bash
$ ../_build/bin/cachesim ../data/cloudPhysicsIO.vscsi vscsi s3fifo 0.0000001 --ignore-obj-size 0
../data/cloudPhysicsIO.vscsi S3FIFO-0.1000-2 cache size      202,           113872 req, miss ratio 1.0000, throughput 8.51 MQPS
```

After modification,

```bash
$ ../_build/bin/cachesim ../data/cloudPhysicsIO.vscsi vscsi s3fifo 0.1 --ignore-obj-size 1
../data/cloudPhysicsIO.vscsi S3FIFO-0.1000-2 cache size     4897,           113872 req, miss ratio 0.7525, throughput 6.81 MQPS

$ ../_build/bin/cachesim ../data/cloudPhysicsIO.vscsi vscsi s3fifo 0.0000001 --ignore-obj-size 0
../data/cloudPhysicsIO.vscsi S3FIFO-0.1000-2 cache size     202B,           113872 req, miss ratio 1.0000, throughput 11.71 MQPS
```