### PR TITLE
fix: header-only library issue - symbol not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__
 *.clean
 *.nogit*
 *_build*
+*.out
 build
 .idea
 example/cacheSimulatorC/cmake-build-debug

--- a/README.md
+++ b/README.md
@@ -223,9 +223,13 @@ free_request(req);
 cache->cache_free(cache);
 ```
 
-save this to `test.c` and compile it with 
-``` bash
-gcc test.c $(pkg-config --cflags --libs libCacheSim glib-2.0) -o test.out
+save this to `test.c` and compile it with below command. For `libCacheSim.h` to work correctly we need the following libs to be installed first: [glib](https://developer.gnome.org/glib/) and [zstd](https://github.com/facebook/zstd). Please check the previous section [installation](#install-dependency).
+```bash
+gcc test.c $(pkg-config --cflags --libs libCacheSim glib-2.0) -o test.out -lm -lzstd
+```
+To run the executable,
+```bash
+./test.out
 ```
 
 See [here](/doc/advanced_lib.md) for more details, and see [example folder](/example) for examples on how to use libCacheSim, such as building a cache cluster with consistent hashing, multi-layer cache simulators. 

--- a/doc/install.md
+++ b/doc/install.md
@@ -63,15 +63,11 @@ brew install pkg-config
 ```
 
 #### Install zstd
-
-zstd must be installed from source
-
+Use the below command to install
 ```bash
-wget https://github.com/facebook/zstd/releases/download/v1.5.0/zstd-1.5.0.tar.gz
-tar xvf zstd-1.5.0.tar.gz
-pushd zstd-1.5.0/build/cmake/
-mkdir _build && cd _build/
-cmake .. && make -j
-sudo make install
-popd
+brew install zstd
+```
+If still shows zstd not found after compilation, try
+```bash
+brew link zstd
 ```


### PR DESCRIPTION
Fix the linker issue while including libcachesim as header-only file and compiling.
- add *.out executable to .gitignore
- fix linker issue with -lm and -lzstd
![image](https://github.com/user-attachments/assets/d72a29e9-1fb6-4a22-809c-8ffe534e1045)
