### PR TITLE
feat: scale both size and result when use sample

### DIFF
--- a/libCacheSim/bin/cachesim/internal.h
+++ b/libCacheSim/bin/cachesim/internal.h
@@ -27,6 +27,8 @@ struct arguments {
   char *admission_algo;
   char *prefetch_algo;
   uint64_t cache_sizes[N_MAX_CACHE_SIZE];
+  // Sample will scale the cache size, keep the original size for output
+  uint64_t origin_cache_sizes[N_MAX_CACHE_SIZE];
   int n_cache_size;
   int warmup_sec;
 
@@ -57,9 +59,8 @@ void parse_cmd(int argc, char *argv[], struct arguments *args);
 
 void free_arg(struct arguments *args);
 
-void simulate(reader_t *reader, cache_t *cache, int report_interval,
-              int warmup_sec, char *ofilepath, bool ignore_obj_size,
-              bool print_head_req);
+void simulate(reader_t *reader, uint64_t origin_cache_size,cache_t *cache, int report_interval, int warmup_sec, char *ofilepath,
+              bool ignore_obj_size, bool print_head_req, sampler_t *sampler);
 
 void print_parsed_args(struct arguments *args);
 

--- a/libCacheSim/include/libCacheSim/cache.h
+++ b/libCacheSim/include/libCacheSim/cache.h
@@ -86,6 +86,9 @@ typedef struct {
   int64_t curr_rtime;
   int64_t expired_obj_cnt;
   int64_t expired_bytes;
+
+  // for sampling
+  double_t result_scale_ratio;
   char cache_name[CACHE_NAME_ARRAY_LEN];
 } cache_stat_t;
 

--- a/libCacheSim/include/libCacheSim/sampling.h
+++ b/libCacheSim/include/libCacheSim/sampling.h
@@ -32,16 +32,19 @@ typedef struct sampler {
   clone_sampler_func clone;
   free_sampler_func free;
   enum sampler_type type;
+  ssize_t total_count;
+  ssize_t access_count;
 } sampler_t;
 
 sampler_t *create_spatial_sampler(double sampling_ratio);
 
 sampler_t *create_temporal_sampler(double sampling_ratio);
 
+double scale_miss_ratio(sampler_t *sample, double miss_ratio);
+
 static inline void print_sampler(sampler_t *sampler) {
-  printf("%s sampler: sample ratio %lf, sample func %p, clone func %p\n",
-         sampling_type_str[sampler->type], sampler->sampling_ratio,
-         sampler->sample, sampler->clone);
+  printf("%s sampler: sample ratio %lf, sample func %p, clone func %p\n", sampling_type_str[sampler->type],
+         sampler->sampling_ratio, sampler->sample, sampler->clone);
 }
 
 #ifdef __cplusplus

--- a/libCacheSim/profiler/simulator.c
+++ b/libCacheSim/profiler/simulator.c
@@ -123,6 +123,15 @@ static void _simulate(gpointer data, gpointer user_data) {
   strncpy(result[idx].cache_name, local_cache->cache_name,
           CACHE_NAME_ARRAY_LEN);
 
+if (cloned_reader->sampler) {
+    sampler_t *sampler = cloned_reader->sampler;
+    double_t result_scale_ratio = (double_t)sampler->access_count / ((double_t)sampler->total_count * sampler->sampling_ratio);
+
+    double_t scaled_n_miss = (double_t)result[idx].n_miss * result_scale_ratio;
+    double_t scaled_n_miss_byte = (double_t)result[idx].n_miss_byte * result_scale_ratio;
+    result[idx].n_miss = scaled_n_miss;
+    result[idx].n_miss_byte = scaled_n_miss_byte;
+}
   // report progress
   g_mutex_lock(&(params->mtx));
   (*(params->progress))++;

--- a/libCacheSim/traceReader/sampling/spatial.c
+++ b/libCacheSim/traceReader/sampling/spatial.c
@@ -2,22 +2,26 @@
  * a spatial sampler that samples sampling_ratio of objects from the trace
  **/
 
+#include "../../dataStructure/hash/hash.h"
 #include "../../include/libCacheSim/logging.h"
 #include "../../include/libCacheSim/sampling.h"
-#include "../../dataStructure/hash/hash.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 bool spatial_sample(sampler_t *sampler, request_t *req) {
+  static const uint64_t MODULES = 1 << 18;
   uint64_t hash_value = req->hv;
   if (hash_value == 0) {
     hash_value = get_hash_value_int_64(&(req->obj_id));
     req->hv = hash_value;
   }
 
-  return hash_value % sampler->sampling_ratio_inv == 0;
+  bool is_sampled = (hash_value % MODULES) < (sampler->sampling_ratio * MODULES);
+  sampler->total_count += 1;
+  sampler->access_count += is_sampled;
+  return is_sampled;
 }
 
 sampler_t *clone_spatial_sampler(const sampler_t *sampler) {
@@ -32,8 +36,7 @@ void free_spatial_sampler(sampler_t *sampler) { free(sampler); }
 
 sampler_t *create_spatial_sampler(double sampling_ratio) {
   if (sampling_ratio > 1 || sampling_ratio <= 0) {
-    ERROR("sampling ratio range error get %lf (should be 0-1)\n",
-          sampling_ratio);
+    ERROR("sampling ratio range error get %lf (should be 0-1)\n", sampling_ratio);
   } else if (sampling_ratio > 0.5) {
     ERROR("currently we only support sampling ratio no more than 0.5\n");
   } else if (sampling_ratio == 1) {
@@ -49,12 +52,26 @@ sampler_t *create_spatial_sampler(double sampling_ratio) {
   s->clone = clone_spatial_sampler;
   s->free = free_spatial_sampler;
   s->type = SPATIAL_SAMPLER;
+  s->total_count = 0;
+  s->access_count = 0;
   // s->sampling_boundary = (uint64_t)(ratio * UINT64_MAX);
 
   print_sampler(s);
 
   VVERBOSE("create spatial sampler with ratio %lf\n", sampling_ratio);
   return s;
+}
+
+double scale_miss_ratio(sampler_t *sampler, double miss_ratio) {
+  if (sampler->type == SPATIAL_SAMPLER) {
+    ssize_t total_count = sampler->total_count;
+    ssize_t access_count = sampler->access_count;
+    ssize_t expected_count = total_count * sampler->sampling_ratio;
+    return (double)(miss_ratio * access_count) / (double)expected_count;
+  } else {
+    ERROR("Invalid sampler type for scaling miss ratio\n");
+    return -1;  // Return an error value for invalid sampler types
+  }
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
sample ratio 0.1 on a small trace
```
./bin/cachesim ../data/twitter_cluster52.csv csv lru 10kb,100kb,2mb,4mb,8mb,16mb,32mb,64mb -t "time-col=1, obj-id-col=2, obj-size-col=3, delimiter=," --sample-ratio 0.1
```
sampling result is 
```
result/twitter_cluster52.csv                              LRU cache size       10KiB, 83463 req, miss ratio 0.6038, byte miss ratio 0.6853
result/twitter_cluster52.csv                              LRU cache size      100KiB, 83463 req, miss ratio 0.4145, byte miss ratio 0.4422
result/twitter_cluster52.csv                              LRU cache size     2048KiB, 83463 req, miss ratio 0.2321, byte miss ratio 0.2352
result/twitter_cluster52.csv                              LRU cache size     4096KiB, 83463 req, miss ratio 0.1957, byte miss ratio 0.1939
result/twitter_cluster52.csv                              LRU cache size     8192KiB, 83463 req, miss ratio 0.1664, byte miss ratio 0.1614
result/twitter_cluster52.csv                              LRU cache size    16384KiB, 83463 req, miss ratio 0.1491, byte miss ratio 0.1430
result/twitter_cluster52.csv                              LRU cache size    32768KiB, 83463 req, miss ratio 0.1440, byte miss ratio 0.1373
result/twitter_cluster52.csv                              LRU cache size    65536KiB, 83463 req, miss ratio 0.1440, byte miss ratio 0.1373
```
without sampling

```
result/twitter_cluster52.csv                              LRU cache size       10KiB, 1000000 req, miss ratio 0.6118, byte miss ratio 0.6522
result/twitter_cluster52.csv                              LRU cache size      100KiB, 1000000 req, miss ratio 0.4061, byte miss ratio 0.4348
result/twitter_cluster52.csv                              LRU cache size     2048KiB, 1000000 req, miss ratio 0.2263, byte miss ratio 0.2348
result/twitter_cluster52.csv                              LRU cache size     4096KiB, 1000000 req, miss ratio 0.1920, byte miss ratio 0.1963
result/twitter_cluster52.csv                              LRU cache size     8192KiB, 1000000 req, miss ratio 0.1652, byte miss ratio 0.1670
result/twitter_cluster52.csv                              LRU cache size    16384KiB, 1000000 req, miss ratio 0.1483, byte miss ratio 0.1483
result/twitter_cluster52.csv                              LRU cache size    32768KiB, 1000000 req, miss ratio 0.1435, byte miss ratio 0.1431
result/twitter_cluster52.csv                              LRU cache size    65536KiB, 1000000 req, miss ratio 0.1435, byte miss ratio 0.1431
```