### PR TITLE
fix: reset n_read_req to 0

### DIFF
--- a/libCacheSim/traceReader/reader.c
+++ b/libCacheSim/traceReader/reader.c
@@ -560,6 +560,7 @@ int skip_n_req(reader_t *reader, const int N) {
 void reset_reader(reader_t *const reader) {
   /* rewind the reader back to beginning */
   long curr_offset = 0;
+  reader->n_read_req = 0;
   if (reader->trace_type == PLAIN_TXT_TRACE) {
     fseek(reader->file, 0, SEEK_SET);
     curr_offset = ftell(reader->file);


### PR DESCRIPTION
To solve the following issue when set a value of `num-req`, (reason is that when cal working set, `reset_reader()` will not reset `n_read_req`)
```
Haocheng@node0:~/debug/libCacheSim$ ./_build/bin/cachesim ./data/cloudPhysicsIO.txt txt S3FIFO 0.1 --num-req=10
[INFO]  09-19-2024 04:12:26 cli_reader_utils.c:262  (tid=140213382518144): calculating working set size...
[INFO]  09-19-2024 04:12:26 cli_reader_utils.c:279  (tid=140213382518144): working set size: 10 object 10 byte
[INFO]  09-19-2024 04:12:26 cli_parser.c:553  (tid=140213382518144): trace path: ./data/cloudPhysicsIO.txt, trace_type PLAIN_TXT_TRACE, ofilepath cloudPhysicsIO.txt.cachesim, 40 threads, warmup -1 sec, total 1 algo x 1 size = 1 caches, S3FIFO
./data/cloudPhysicsIO.txt S3FIFO-0.1000-2 cache size       1B,                0 req, miss ratio -nan, throughput 0.00 MQPS
```

->

```
Haocheng@node0:~/debug/libCacheSim$ ./_build/bin/cachesim ./data/cloudPhysicsIO.txt txt S3FIFO 0.1 --num-req=10
[INFO]  09-19-2024 04:21:26 cli_reader_utils.c:262  (tid=140444731770240): calculating working set size...
[INFO]  09-19-2024 04:21:26 cli_reader_utils.c:279  (tid=140444731770240): working set size: 10 object 10 byte
[INFO]  09-19-2024 04:21:26 cli_parser.c:553  (tid=140444731770240): trace path: ./data/cloudPhysicsIO.txt, trace_type PLAIN_TXT_TRACE, ofilepath cloudPhysicsIO.txt.cachesim, 40 threads, warmup -1 sec, total 1 algo x 1 size = 1 caches, S3FIFO
[INFO]  09-19-2024 04:21:26 request.h:117  (tid=140444731770240): req clcok_time 0, id 1, size 1, op invalid, valid 1
[INFO]  09-19-2024 04:21:26 request.h:117  (tid=140444731770240): req clcok_time 0, id 2, size 1, op invalid, valid 1
[DEBUG] 09-19-2024 04:21:26 request.h:117  (tid=140444731770240): req clcok_time 0, id 3, size 1, op invalid, valid 1
[DEBUG] 09-19-2024 04:21:26 request.h:117  (tid=140444731770240): req clcok_time 0, id 4, size 1, op invalid, valid 1
[DEBUG] 09-19-2024 04:21:26 request.h:117  (tid=140444731770240): req clcok_time 0, id 5, size 1, op invalid, valid 1
[DEBUG] 09-19-2024 04:21:26 request.h:117  (tid=140444731770240): req clcok_time 0, id 6, size 1, op invalid, valid 1
[DEBUG] 09-19-2024 04:21:26 request.h:117  (tid=140444731770240): req clcok_time 0, id 7, size 1, op invalid, valid 1
[DEBUG] 09-19-2024 04:21:26 request.h:117  (tid=140444731770240): req clcok_time 0, id 8, size 1, op invalid, valid 1
[DEBUG] 09-19-2024 04:21:26 request.h:117  (tid=140444731770240): req clcok_time 0, id 9, size 1, op invalid, valid 1
[DEBUG] 09-19-2024 04:21:26 request.h:117  (tid=140444731770240): req clcok_time 0, id 10, size 1, op invalid, valid 1
./data/cloudPhysicsIO.txt S3FIFO-0.1000-2 cache size       1B,               10 req, miss ratio 1.0000, throughput 0.11 MQPS
```