### PR TITLE
[fix] LIRS_find when update_cache is false

### DIFF
--- a/libCacheSim/cache/eviction/LIRS.c
+++ b/libCacheSim/cache/eviction/LIRS.c
@@ -211,7 +211,21 @@ static cache_obj_t *LIRS_find(cache_t *cache, const request_t *req,
   obj_q = params->LRU_q->find(params->LRU_q, req, update_cache);
 
   if (update_cache == false) {
-    return obj_s != NULL ? obj_s : obj_q;
+    if (obj_s != NULL) {
+      if (obj_s->LIRS.is_LIR || obj_s->LIRS.in_cache) {
+        return obj_s;
+      } else {
+        return NULL;
+      }
+    } else if (obj_q != NULL) {
+      if (obj_q->LIRS.in_cache) {
+        return obj_q;
+      } else {
+        return NULL;
+      }
+    } else {
+      return NULL;
+    }
   }
 
   // cache_obj_t *res = NULL;

--- a/libCacheSim/cache/eviction/LIRS.c
+++ b/libCacheSim/cache/eviction/LIRS.c
@@ -210,6 +210,10 @@ static cache_obj_t *LIRS_find(cache_t *cache, const request_t *req,
   obj_s = params->LRU_s->find(params->LRU_s, req, update_cache);
   obj_q = params->LRU_q->find(params->LRU_q, req, update_cache);
 
+  if (update_cache == false) {
+    return obj_s != NULL ? obj_s : obj_q;
+  }
+
   // cache_obj_t *res = NULL;
   if (obj_s != NULL) {
     if (obj_s->LIRS.is_LIR) {


### PR DESCRIPTION
directly return `obj` when `update_cache == false` in `LIRS_find`