### PR TITLE
enable option -o for simulate_with_multi_caches

### DIFF
--- a/libCacheSim/bin/cachesim/cli_parser.c
+++ b/libCacheSim/bin/cachesim/cli_parser.c
@@ -291,7 +291,7 @@ void parse_cmd(int argc, char *argv[], struct arguments *args) {
 
   if (args->ofilepath[0] == '\0') {
     char *trace_filename = rindex(args->trace_path, '/');
-    snprintf(args->ofilepath, OFILEPATH_LEN, "%s.cachesim",
+    snprintf(args->ofilepath, OFILEPATH_LEN, "result/%s.cachesim",
              trace_filename == NULL ? args->trace_path : trace_filename + 1);
   }
 

--- a/libCacheSim/bin/cachesim/main.c
+++ b/libCacheSim/bin/cachesim/main.c
@@ -31,11 +31,13 @@ int main(int argc, char **argv) {
       args.reader, args.caches, args.n_cache_size * args.n_eviction_algo, NULL,
       0, args.warmup_sec, args.n_thread, true, true);
 
+  // output to file
   char output_str[1024];
-  char output_filename[128];
-  create_dir("result/");
-  sprintf(output_filename, "result/%s", basename(args.trace_path));
-  FILE *output_file = fopen(output_filename, "a");
+  FILE *output_file = fopen(args.ofilepath, "a");
+  if (output_file == NULL) {
+    ERROR("cannot open file %s %s\n", args.ofilepath, strerror(errno));
+    exit(1);
+  }
 
   uint64_t size_unit = 1;
   char *size_unit_str = "";
@@ -57,9 +59,9 @@ int main(int argc, char **argv) {
   printf("\n");
   for (int i = 0; i < args.n_cache_size * args.n_eviction_algo; i++) {
     snprintf(output_str, 1024,
-             "%s %32s cache size %8ld%s, %lld req, miss ratio %.4lf, byte miss "
+             "%s %s cache size %8ld%s, %lld req, miss ratio %.4lf, byte miss "
              "ratio %.4lf\n",
-             output_filename, result[i].cache_name,
+             args.reader->trace_path, result[i].cache_name,
              (long)(result[i].cache_size / size_unit), size_unit_str,
              (long long)result[i].n_req,
              (double)result[i].n_miss / (double)result[i].n_req,

--- a/libCacheSim/bin/cachesim/main.c
+++ b/libCacheSim/bin/cachesim/main.c
@@ -33,6 +33,14 @@ int main(int argc, char **argv) {
 
   // output to file
   char output_str[1024];
+  // ensure file path exists
+  char *output_dir = rindex(args.ofilepath, '/');
+  if (output_dir != NULL) {
+    size_t dir_length = output_dir - args.ofilepath;
+    char dir_path[1024];
+    snprintf(dir_path, dir_length + 1, "%s", args.ofilepath);
+    create_dir(dir_path);
+  }
   FILE *output_file = fopen(args.ofilepath, "a");
   if (output_file == NULL) {
     ERROR("cannot open file %s %s\n", args.ofilepath, strerror(errno));

--- a/libCacheSim/bin/cachesim/sim.c
+++ b/libCacheSim/bin/cachesim/sim.c
@@ -96,7 +96,13 @@ void simulate(reader_t *reader, cache_t *cache, int report_interval, int warmup_
 
 #pragma GCC diagnostic pop
   printf("%s", output_str);
-
+  char *output_dir = rindex(ofilepath, '/');
+  if (output_dir != NULL) {
+    size_t dir_length = output_dir - ofilepath;
+    char dir_path[1024];
+    snprintf(dir_path, dir_length + 1, "%s", ofilepath);
+    create_dir(dir_path);
+  }
   FILE *output_file = fopen(ofilepath, "a");
   if (output_file == NULL) {
     ERROR("cannot open file %s %s\n", ofilepath, strerror(errno));

--- a/libCacheSim/bin/cachesim/sim.c
+++ b/libCacheSim/bin/cachesim/sim.c
@@ -102,7 +102,7 @@ void simulate(reader_t *reader, cache_t *cache, int report_interval, int warmup_
     ERROR("cannot open file %s %s\n", ofilepath, strerror(errno));
     exit(1);
   }
-  fprintf(output_file, "%s\n", output_str);
+  fprintf(output_file, "%s", output_str);
   fclose(output_file);
 
 #if defined(TRACK_EVICTION_V_AGE)

--- a/libCacheSim/utils/mysys.c
+++ b/libCacheSim/utils/mysys.c
@@ -97,10 +97,35 @@ double gettime(void) {
   return tv.tv_sec + tv.tv_usec / 1000000.0;
 }
 
+// void create_dir(char *dir_path) {
+//   if (access(dir_path, F_OK) == -1) {
+//     mkdir(dir_path, 0777);
+//   }
+// }
+
 void create_dir(char *dir_path) {
-  if (access(dir_path, F_OK) == -1) {
-    mkdir(dir_path, 0777);
-  }
+    char temp[1024];
+    snprintf(temp, sizeof(temp), "%s", dir_path);
+    size_t len = strlen(temp);
+    if (temp[len - 1] == '/') {
+        temp[len - 1] = '\0';
+    }
+    for (char *p = temp + 1; *p; p++) {
+        if (*p == '/') {
+            *p = '\0';
+            if (access(temp, F_OK) == -1) {
+                if (mkdir(temp, 0777) == -1) {
+                    perror("mkdir error");
+                }
+            }
+            *p = '/';
+        }
+    }
+    if (access(temp, F_OK) == -1) {
+        if (mkdir(temp, 0777) == -1) {
+            perror("mkdir error");
+        }
+    }
 }
 
 void get_resouce_usage(struct rusage *r_usage) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,8 @@ target_link_libraries(testPrefetchAlgo ${coreLib})
 add_executable(testDataStructure test_dataStructure.c)
 target_link_libraries(testDataStructure ${coreLib})
 
+add_executable(testUtils test_utils.c)
+target_link_libraries(testUtils ${coreLib})
 
 add_test(NAME testReader COMMAND testReader WORKING_DIRECTORY .)
 add_test(NAME testDistUtils COMMAND testDistUtils WORKING_DIRECTORY .)
@@ -30,6 +32,7 @@ add_test(NAME testSimulator COMMAND testSimulator WORKING_DIRECTORY .)
 add_test(NAME testEvictionAlgo COMMAND testEvictionAlgo WORKING_DIRECTORY .)
 add_test(NAME testPrefetchAlgo COMMAND testPrefetchAlgo WORKING_DIRECTORY .)
 add_test(NAME testDataStructure COMMAND testDataStructure WORKING_DIRECTORY .)
+add_test(NAME testUtils COMMAND testUtils WORKING_DIRECTORY .)
 
 # if (ENABLE_GLCACHE)
 #     add_executable(testGLCache test_glcache.c)

--- a/test/test_utils.c
+++ b/test/test_utils.c
@@ -1,0 +1,52 @@
+//
+// Created by Haocheng on 01/14/25.
+//
+
+#include "../libCacheSim/utils/include/mysys.h"
+#include "common.h"
+
+bool directory_exists(const char *path) {
+    struct stat info;
+    return (stat(path, &info) == 0 && (info.st_mode & S_IFDIR));
+}
+
+void test_create_dir(gconstpointer user_data) {
+    char base_dir[] = "/tmp/gtest_dir_test";
+
+    if (directory_exists(base_dir)) {
+        if(system("rm -rf /tmp/gtest_dir_test") != 0) {
+            perror("Failed to delete file");
+        }
+
+    }
+
+    // case 1: single dir
+    char single_dir[1024];
+    snprintf(single_dir, sizeof(single_dir), "%s/single", base_dir);
+    create_dir(single_dir);
+    g_assert_true(directory_exists(single_dir));
+
+    // case 2: multi dir
+    char multi_dir[1024];
+    snprintf(multi_dir, sizeof(multi_dir), "%s/multi/level/directory", base_dir);
+    create_dir(multi_dir);
+    g_assert_true(directory_exists(multi_dir));
+
+    // case 3: dir exists
+    create_dir(single_dir);
+    g_assert_true(directory_exists(single_dir));
+
+    // case 4: tail /
+    char slash_dir[1024];
+    snprintf(slash_dir, sizeof(slash_dir), "%s/with_slash/", base_dir);
+    create_dir(slash_dir);
+    g_assert_true(directory_exists(slash_dir));
+
+    // printf("All create_dir tests passed!\n");
+}
+
+int main(int argc, char *argv[]) {
+    g_test_init(&argc, &argv, NULL);
+    g_test_add_data_func("/test_create_dir", NULL, test_create_dir);
+    return g_test_run();
+}


### PR DESCRIPTION
In current impl, -o will not affect the output file when there are multiple caches,

e.g., 
```
cachesim ~/cf_allcolo.ns2.oracleGeneral.zst oracleGeneral  s3fifo 0.1 -o tmp
# output path: tmp

cachesim ~/cf_allcolo.ns2.oracleGeneral.zst oracleGeneral  s3fifo 0.1,0.01 -o tmp
# output path: result/cf_allcolo.ns2.oracleGeneral.zst
```

Summarize the current stats as the following table,

| option | single or multi | output file |
| - | - | - |
| no -o option | single | trace_name.cachesim |
| no -o option | multi | result/trace_name |
| with -o option (-o customized_opath) | single |  customized_opath |
| with -o option (-o customized_opath) | multi | result/trace_name |


To unify behavior, we change it to

| option | single or multi | output file |
| - | - | - |
| no -o option | single | trace_name.cachesim |
| no -o option | multi | trace_name.cachesim |
| with -o option (-o customized_opath) | single | customized_opath |
| with -o option (-o customized_opath) | multi | customized_opath |