### PR TITLE
update xgboost inferface for GLCache

### DIFF
--- a/libCacheSim/cache/eviction/GLCache/dataPrep.c
+++ b/libCacheSim/cache/eviction/GLCache/dataPrep.c
@@ -293,10 +293,13 @@ static void prepare_training_data_per_package(cache_t *cache) {
   // safe_call(XGDMatrixSetUIntInfo(learner->train_dm, "group", group,
   // n_group));
 
-  safe_call(XGDMatrixSetUIntInfo(learner->train_dm, "group",
-                                 &learner->n_train_samples, 1));
-  safe_call(XGDMatrixSetUIntInfo(learner->valid_dm, "group",
-                                 &learner->n_valid_samples, 1));
+  // convert to array interface format
+  char str_n_valid_sample[128];
+  snprintf(str_n_valid_sample, sizeof(str_n_valid_sample),
+           "{\"data\": [%llu],\"shape\": [1],\"typestr\": \"<u4\",\"version\": 3}",
+           (unsigned long long)(uintptr_t)&learner->n_valid_samples);
+  safe_call(XGDMatrixSetUIntInfo(learner->train_dm, "group", str_n_valid_sample));
+  safe_call(XGDMatrixSetUIntInfo(learner->valid_dm, "group", str_n_valid_sample));
 #endif
 }
 

--- a/libCacheSim/cache/eviction/GLCache/inference.c
+++ b/libCacheSim/cache/eviction/GLCache/inference.c
@@ -41,7 +41,7 @@ static int prepare_inference_data(cache_t *cache) {
 
   feature_t *x = learner->inference_x;
 
-  int n_segs = 0;
+  unsigned int n_segs = 0;
   int inv_sample_ratio = MAX(params->n_in_use_segs / N_INFERENCE_DATA, 1);
   int credit = inv_sample_ratio;
   // printf("%d %d\n", params->n_in_use_segs, inv_sample_ratio);
@@ -66,8 +66,13 @@ static int prepare_inference_data(cache_t *cache) {
   }
   safe_call(XGDMatrixCreateFromMat(learner->inference_x, n_segs,
                                    learner->n_feature, -2, &learner->inf_dm));
-
-  safe_call(XGDMatrixSetUIntInfo(learner->inf_dm, "group", &n_segs, 1));
+  
+  // convert to array interface format
+  char str_n_segs[128];
+  snprintf(str_n_segs, sizeof(str_n_segs),
+           "{\"data\": [%llu],\"shape\": [1],\"typestr\": \"<u4\",\"version\": 3}",
+           (unsigned long long)(uintptr_t)&n_segs);
+  safe_call(XGDMatrixSetInfoFromInterface(learner->inf_dm, "group", str_n_segs));
 
   return n_segs;
 }


### PR DESCRIPTION
Resolve the following warning for GLCache.
```
[18:23:16] WARNING: /tmp/xgboost/src/c_api/c_api.cc:673: `XGDMatrixSetUIntInfo` is deprecated since2.1.0, use `XGDMatrixSetInfoFromInterface` instead.
```

Using the new interface does not affect performance.
```
# new interface
tencentBlock.ns1058.oracleGeneral.zst GLCache cache size     9489,          7963358 req, miss ratio 0.0675, throughput 3.53 MQPS

real    0m3.243s
user    0m3.076s
sys     0m0.160s

# old one
tencentBlock.ns1058.oracleGeneral.zst GLCache cache size     9489,          7963358 req, miss ratio 0.0675, throughput 3.43 MQPS

real    0m3.304s
user    0m3.180s
sys     0m0.121s
```