### PR TITLE
integrated clockpro to the libCacheSim

### DIFF
--- a/libCacheSim/bin/cachesim/cache_init.h
+++ b/libCacheSim/bin/cachesim/cache_init.h
@@ -15,11 +15,11 @@ extern "C" {
 static inline cache_t *create_cache(const char *trace_path, const char *eviction_algo, const uint64_t cache_size,
                                     const char *eviction_params, const bool consider_obj_metadata) {
   common_cache_params_t cc_params = {
-      .cache_size = cache_size,
-      .default_ttl = 86400 * 300,
-      .hashpower = 24,
-      .consider_obj_metadata = consider_obj_metadata,
-  };
+    .cache_size = cache_size,
+    .default_ttl = 86400 * 300,
+    .hashpower = 24,
+    .consider_obj_metadata = consider_obj_metadata,
+};
   cache_t *cache;
 
   /* the trace provided is small */
@@ -105,6 +105,8 @@ static inline cache_t *create_cache(const char *trace_path, const char *eviction
   } else if (strcasecmp(eviction_algo, "fifo-reinsertion") == 0 || strcasecmp(eviction_algo, "clock") == 0 ||
              strcasecmp(eviction_algo, "second-chance") == 0) {
     cache = Clock_init(cc_params, eviction_params);
+  } else if (strcasecmp(eviction_algo, "clockpro") == 0) {
+    cache = ClockPro_init(cc_params, eviction_params);
   } else if (strcasecmp(eviction_algo, "lirs") == 0) {
     cache = LIRS_init(cc_params, eviction_params);
   } else if (strcasecmp(eviction_algo, "fifomerge") == 0 || strcasecmp(eviction_algo, "fifo-merge") == 0) {

--- a/libCacheSim/cache/eviction/CMakeLists.txt
+++ b/libCacheSim/cache/eviction/CMakeLists.txt
@@ -8,6 +8,7 @@ set(sourceC
         FIFO.c
         LRU.c
         Clock.c
+        ClockPro.c
         SLRU.c
         SLRUv0.c
         CR_LFU.c

--- a/libCacheSim/cache/eviction/ClockPro.c
+++ b/libCacheSim/cache/eviction/ClockPro.c
@@ -1,0 +1,492 @@
+//
+// ClockPro replacement algorithm
+// https://www.usenix.org/legacy/event/usenix05/tech/general/full_papers/jiang/jiang.pdf
+//
+// Inspirations are taken from
+// https://bitbucket.org/SamiLehtinen/pyclockpro/src/master/
+// https://blog.yufeng.info/wp-content/uploads/2010/08/8-Clock-Pro.pdf
+//
+// libCacheSim
+//
+// Created by Marthen on 2/12/25.
+// Copyright © 2025 Marthen. All rights reserved.
+//
+
+#include "../../dataStructure/hashtable/hashtable.h"
+#include "../../include/libCacheSim/evictionAlgo.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//#define USE_BELADY
+#undef USE_BELADY
+
+typedef struct ClockPro_params {
+  cache_obj_t *hand_hot;
+  cache_obj_t *hand_cold;
+  cache_obj_t *hand_test;
+
+  int64_t mem_cold_max;
+  int64_t mem_cold;
+  int64_t mem_test;
+  int64_t mem_hot;
+
+  hashtable_t *ht_test;
+
+  bool init_ref;
+} ClockPro_params_t;
+
+static const char *DEFAULT_PARAMS = "init-ref=0,init-ratio-cold=1";
+
+// ***********************************************************************
+// ****                                                               ****
+// ****                   function declarations                       ****
+// ****                                                               ****
+// ***********************************************************************
+
+static void ClockPro_parse_params(cache_t *cache, const char *cache_specific_params);
+static void ClockPro_free(cache_t *cache);
+static bool ClockPro_get(cache_t *cache, const request_t *req);
+static cache_obj_t *ClockPro_find(cache_t *cache, const request_t *req, bool update_cache);
+static cache_obj_t *ClockPro_insert(cache_t *cache, const request_t *req);
+static void ClockPro_evict(cache_t *cache, const request_t *req);
+static bool ClockPro_remove(cache_t *cache, obj_id_t obj_id);
+static bool ClockPro_can_insert(cache_t *cache, const request_t *req);
+static void ClockPro_promote(cache_t *cache, cache_obj_t *obj);
+static void ClockPro_run_test(cache_t *cache);
+static void ClockPro_run_cold(cache_t *cache);
+static void ClockPro_run_hot(cache_t *cache);
+
+// ***********************************************************************
+// ****                                                               ****
+// ****                   end user facing functions                   ****
+// ****                                                               ****
+// ***********************************************************************
+
+/**
+* @brief initialize a ClockPro cache
+*
+* @param ccache_params some common cache parameters
+* @param cache_specific_params Clock specific parameters as a string
+*/
+cache_t *ClockPro_init(const common_cache_params_t ccache_params, const char *cache_specific_params) {
+  cache_t *cache = cache_struct_init("ClockPro", ccache_params, cache_specific_params);
+  cache->cache_init = ClockPro_init;
+  cache->cache_free = ClockPro_free;
+  cache->get = ClockPro_get;
+  cache->find = ClockPro_find;
+  cache->insert = ClockPro_insert;
+  cache->evict = ClockPro_evict;
+  cache->remove = ClockPro_remove;
+  cache->can_insert = ClockPro_can_insert;
+  cache->get_n_obj = cache_get_n_obj_default;
+  cache->get_occupied_byte = cache_get_occupied_byte_default;
+  cache->obj_md_size = 0;
+
+  cache->eviction_params = my_malloc_n(ClockPro_params_t, 1);
+  ClockPro_params_t *params = (ClockPro_params_t *)(cache->eviction_params);
+
+  params->hand_hot = NULL;
+  params->hand_cold = NULL;
+  params->hand_test = NULL;
+  params->mem_cold = 0;
+  params->mem_test = 0;
+  params->mem_hot = 0;
+  params->mem_cold_max = cache->cache_size; // default to the cache size (fallback)
+  params->ht_test = create_hashtable(HASH_POWER_DEFAULT);
+
+  ClockPro_parse_params(cache, DEFAULT_PARAMS);
+  if (cache_specific_params != NULL) {
+    ClockPro_parse_params(cache, cache_specific_params);
+  }
+
+  return cache;
+};
+
+/**
+ * free resources used by this cache
+ *
+ * @param cache
+ */
+static void ClockPro_free(cache_t *cache) {
+  ClockPro_params_t *params = (ClockPro_params_t *)(cache->eviction_params);
+  free_hashtable(params->ht_test);
+  my_free(sizeof(ClockPro_params_t), params);
+  cache_struct_free(cache);
+}
+
+/**
+ * @brief this function is the user facing API
+ * it performs the following logic
+ *
+ * ```
+ * if obj in cache:
+ *    update_metadata
+ *    return true
+ * else:
+ *    if cache does not have enough space:
+ *        evict until it has space to insert
+ *    insert the object
+ *    return false
+ * ```
+ *
+ * @param cache
+ * @param req
+ * @return
+ */
+static bool ClockPro_get(cache_t *cache, const request_t *req) {
+  return cache_get_base(cache, req);
+}
+
+// ***********************************************************************
+// ****                                                               ****
+// ****       developer facing APIs (used by cache developer)         ****
+// ****                                                               ****
+// ***********************************************************************
+
+/**
+ * @brief check whether an object is in the cache
+ *
+ * @param cache
+ * @param req
+ * @param update_cache whether to update the cache,
+ * if true, the object is promoted or set as referenced
+ * and if the object is expired, it is removed from the cache
+ * @return true on hit, false on miss
+ */
+static cache_obj_t *ClockPro_find(cache_t *cache, const request_t *req, const bool update_cache) {
+  cache_obj_t *obj = cache_find_base(cache, req, update_cache);
+
+  if (obj != NULL && update_cache) {
+    if (!obj->clockpro.referenced) {
+      obj->clockpro.referenced = true;
+    }
+  }
+
+  return obj;
+}
+
+/**
+ * @brief insert an object into the cache,
+ * update the hash table and cache metadata
+ * this function assumes the cache has enough space
+ * and eviction is not part of this function
+ *
+ * @param cache
+ * @param req
+ * @return the inserted object
+ */
+static cache_obj_t *ClockPro_insert(cache_t *cache, const request_t *req) {
+  ClockPro_params_t *params = (ClockPro_params_t *)cache->eviction_params;
+
+  // request to insert a test object
+  cache_obj_t *test_obj = hashtable_find_obj_id(params->ht_test, req->obj_id);
+  if (test_obj != NULL) {
+    ClockPro_promote(cache, test_obj);
+    return test_obj;
+  }
+
+  cache_obj_t *obj = cache_insert_base(cache, req);
+  obj->clockpro.referenced = params->init_ref;
+  obj->clockpro.status = COLD;
+
+  if (params->hand_hot == NULL) { // Initial insertion
+    prepend_obj_to_head(&params->hand_hot, &params->hand_hot, obj);
+    params->hand_hot->queue.next = params->hand_hot;
+    params->hand_hot->queue.prev = params->hand_hot;
+    params->hand_cold = params->hand_hot;
+    params->hand_test = params->hand_hot;
+  } else {
+    cache_obj_t *hand_hot_prev = params->hand_hot->queue.prev;
+    prepend_obj_to_head(&params->hand_hot, &hand_hot_prev, obj);
+    obj->queue.prev = hand_hot_prev;
+    obj->queue.prev->queue.next = obj;
+    params->hand_hot = obj->queue.next;
+  }
+
+  params->mem_cold += obj->obj_size;
+
+  return obj;
+}
+
+/**
+ * @brief evict an object from the cache
+ * it needs to call cache_evict_base before returning
+ * which updates some metadata such as n_obj, occupied size, and hash table
+ *
+ * @param cache
+ * @param req not used
+ */
+static void ClockPro_evict(cache_t *cache, const request_t *req) {
+  ClockPro_run_cold(cache);
+}
+
+/**
+ * @brief remove the given object from the cache
+ * note that eviction should not call this function, but rather call
+ * `cache_evict_base` because we track extra metadata during eviction
+ *
+ * and this function is different from eviction
+ * because this is used for user trigger
+ * remove, and eviction is used by the cache to make space for new objects
+ *
+ * it needs to call cache_remove_obj_base before returning
+ * which updates some metadata such as n_obj, occupied size, and hash table
+ *
+ * @param cache
+ * @param obj
+ */
+static void ClockPro_remove_obj(cache_t *cache, cache_obj_t *obj) {
+  ClockPro_params_t *params = (ClockPro_params_t *)cache->eviction_params;
+
+  DEBUG_ASSERT(obj != NULL);
+  cache_obj_t *hand_hot_prev = params->hand_hot->queue.prev;
+
+  if (obj->clockpro.status == TEST) {
+    params->mem_test -= obj->obj_size;
+  } else if (obj->clockpro.status == COLD) {
+    params->mem_cold -= obj->obj_size;
+  } else if (obj->clockpro.status == HOT) {
+    params->mem_hot -= obj->obj_size;
+  }
+
+  if (params->hand_test == obj) {
+    params->hand_test = obj->queue.next;
+  }
+  if (params->hand_cold == obj) {
+    params->hand_cold = obj->queue.next;
+  }
+  if (params->hand_hot == obj) {
+    params->hand_hot = obj->queue.next;
+  }
+
+  remove_obj_from_list(&params->hand_hot, &hand_hot_prev, obj);
+  cache_remove_obj_base(cache, obj, true);
+}
+
+/**
+ * @brief remove an object from the cache
+ * this is different from cache_evict because it is used to for user trigger
+ * remove, and eviction is used by the cache to make space for new objects
+ *
+ * it needs to call cache_remove_obj_base before returning
+ * which updates some metadata such as n_obj, occupied size, and hash table
+ *
+ * @param cache
+ * @param obj_id
+ * @return true if the object is removed, false if the object is not in the
+ * cache
+ */
+static bool ClockPro_remove(cache_t *cache, const obj_id_t obj_id) {
+  cache_obj_t *obj = hashtable_find_obj_id(cache->hashtable, obj_id);
+  if (obj == NULL) {
+    return false;
+  }
+
+  ClockPro_remove_obj(cache, obj);
+
+  return true;
+}
+
+static bool ClockPro_can_insert(cache_t *cache, const request_t *req) {
+  ClockPro_params_t *params = (ClockPro_params_t *)cache->eviction_params;
+  return cache_can_insert_default(cache, req) && (params->mem_cold + req->obj_size <= params->mem_cold_max);
+}
+
+static void ClockPro_run_test(cache_t *cache) {
+  ClockPro_params_t *params = (ClockPro_params_t *)cache->eviction_params;
+  cache_obj_t *obj = params->hand_test;
+
+  if (obj->clockpro.status != TEST) {
+    params->hand_test = obj->queue.next;
+    return;
+  }
+
+  params->mem_test -= obj->obj_size;
+
+  if (params->mem_cold_max > obj->obj_size) {
+    params->mem_cold_max -= obj->obj_size;
+  } else {
+    params->mem_cold_max = 0;
+  }
+
+  if (params->hand_hot == obj) {
+    params->hand_hot = obj->queue.next;
+  }
+  if (params->hand_cold == obj) {
+    params->hand_cold = obj->queue.next;
+  }
+
+  cache_obj_t *hand_test_prev = params->hand_test->queue.prev;
+  remove_obj_from_list(&params->hand_test, &hand_test_prev, obj);
+  hashtable_delete(params->ht_test, obj);
+
+  while (params->mem_cold > params->mem_cold_max) {
+    ClockPro_run_cold(cache);
+  }
+}
+
+static void ClockPro_run_cold(cache_t *cache) {
+  ClockPro_params_t *params = (ClockPro_params_t *)cache->eviction_params;
+  cache_obj_t *obj = params->hand_cold;
+
+  if (obj->clockpro.status != COLD) {
+    params->hand_cold = obj->queue.next;
+    return;
+  }
+
+  if (obj->clockpro.referenced) {
+    ClockPro_promote(cache, obj);
+    return;
+  }
+
+  params->mem_cold -= obj->obj_size;
+
+  while (params->mem_test + obj->obj_size > cache->cache_size) {
+    ClockPro_run_test(cache);
+  }
+
+  request_t req;
+  copy_cache_obj_to_request(&req, obj);
+  cache_obj_t *demoted_obj = hashtable_insert(params->ht_test, &req);
+  demoted_obj->clockpro.referenced = params->init_ref;
+  demoted_obj->clockpro.status = TEST;
+
+  params->mem_test += obj->obj_size;
+
+  demoted_obj->queue.next = params->hand_cold->queue.next;
+  demoted_obj->queue.prev = params->hand_cold->queue.prev;
+
+  params->hand_cold->queue.next->queue.prev = demoted_obj;
+  params->hand_cold->queue.prev->queue.next = demoted_obj;
+
+  if (params->hand_hot == obj) {
+    params->hand_hot = demoted_obj;
+  }
+  if (params->hand_test == obj) {
+    params->hand_test = demoted_obj;
+  }
+
+  cache_evict_base(cache, obj, true);
+  params->hand_cold = demoted_obj->queue.next;
+}
+
+static void ClockPro_run_hot(cache_t *cache) {
+  ClockPro_params_t *params = (ClockPro_params_t *)cache->eviction_params;
+  cache_obj_t *obj = params->hand_hot;
+
+  if (obj->clockpro.status != HOT) {
+    params->hand_hot = obj->queue.next;
+    return;
+  }
+
+  if (obj->clockpro.referenced) {
+    obj->clockpro.referenced = false;
+    params->hand_hot = obj->queue.next;
+    return;
+  }
+
+  while (params->mem_cold + obj->obj_size > params->mem_cold_max) {
+    ClockPro_run_cold(cache);
+  }
+
+  obj->clockpro.status = COLD;
+  obj->clockpro.referenced = params->init_ref;
+
+  if (params->hand_cold == obj) {
+    params->hand_cold = obj->queue.next;
+  }
+  if (params->hand_test == obj) {
+    params->hand_test = obj->queue.next;
+  }
+
+  cache_obj_t *hand_hot_next = params->hand_hot->queue.next;
+  move_obj_to_tail(&hand_hot_next, &params->hand_hot, obj);
+  params->hand_hot = obj->queue.next;
+
+  params->mem_hot -= obj->obj_size;
+  params->mem_cold += obj->obj_size;
+}
+
+static void ClockPro_promote(cache_t *cache, cache_obj_t *obj) {
+  ClockPro_params_t *params = (ClockPro_params_t *)cache->eviction_params;
+
+  if (obj->clockpro.status == TEST) {
+    if (params->mem_cold_max + (int64_t)obj->obj_size > cache->cache_size) {
+      params->mem_cold_max = cache->cache_size;
+    } else {
+      params->mem_cold_max += (int64_t)obj->obj_size;
+    }
+  }
+
+  while ((params->mem_hot + obj->obj_size) > (cache->cache_size - params->mem_cold_max)) {
+    ClockPro_run_hot(cache);
+  }
+
+  if (params->hand_cold == obj) {
+    params->hand_cold = obj->queue.next;
+  }
+  if (params->hand_test == obj) {
+    params->hand_test = obj->queue.next;
+  }
+
+  clockpro_status_e old_status = obj->clockpro.status;
+  obj->clockpro.status = HOT;
+  obj->clockpro.referenced = params->init_ref;
+  cache_obj_t *hand_hot_next = params->hand_hot->queue.next;
+  move_obj_to_tail(&hand_hot_next, &params->hand_hot, obj);
+  obj->queue.next  = hand_hot_next;
+  hand_hot_next->queue.prev = obj;
+
+  params->hand_hot = obj->queue.next;
+
+  if (old_status == COLD) {
+    params->mem_cold -= obj->obj_size;
+  } else if (old_status == TEST) {
+    params->mem_test -= obj->obj_size;
+  }
+
+  params->mem_hot += obj->obj_size;
+}
+
+// ***********************************************************************
+// ****                                                               ****
+// ****                  parameter set up functions                   ****
+// ****                                                               ****
+// ***********************************************************************
+static const char *ClockPro_current_params(cache_t *cache, ClockPro_params_t *params) {
+  static __thread char params_str[128];
+  snprintf(params_str, 128, "\n");
+  return params_str;
+}
+
+static void ClockPro_parse_params(cache_t *cache, const char *cache_specific_params) {
+  ClockPro_params_t *params = (ClockPro_params_t *)(cache->eviction_params);
+  char *params_str = strdup(cache_specific_params);
+  char *old_params_str = params_str;
+  char *end;
+
+  while (params_str != NULL && params_str[0] != '\0') {
+    char *key = strsep((char **)&params_str, "=");
+    char *value = strsep((char **)&params_str, ",");
+
+    while (params_str != NULL && *params_str == ' ') {
+      params_str++;
+    }
+
+    if (strcasecmp(key, "init-ref") == 0) {
+      params->init_ref = strtol(value, &end, 10);
+    } else if (strcasecmp(key, "init-ratio-cold") == 0) {
+      const double ratio = strtod(value, &end);
+      params->mem_cold_max = (int64_t)((double)cache->cache_size * ratio);
+    } else {
+      ERROR("%s does not have parameter %s\n", cache->cache_name, key);
+    }
+  }
+  free(old_params_str);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/libCacheSim/cache/eviction/ClockPro.c
+++ b/libCacheSim/cache/eviction/ClockPro.c
@@ -457,7 +457,7 @@ static void ClockPro_promote(cache_t *cache, cache_obj_t *obj) {
 // ***********************************************************************
 static const char *ClockPro_current_params(cache_t *cache, ClockPro_params_t *params) {
   static __thread char params_str[128];
-  snprintf(params_str, 128, "\n");
+  snprintf(params_str, 128, "init-ref=%d\n", params->init_ref);
   return params_str;
 }
 
@@ -480,6 +480,9 @@ static void ClockPro_parse_params(cache_t *cache, const char *cache_specific_par
     } else if (strcasecmp(key, "init-ratio-cold") == 0) {
       const double ratio = strtod(value, &end);
       params->mem_cold_max = (int64_t)((double)cache->cache_size * ratio);
+    } else if (strcasecmp(key, "print") == 0) {
+      printf("current parameters: %s\n", ClockPro_current_params(cache, params));
+      exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);
     }

--- a/libCacheSim/cache/eviction/ClockPro.c
+++ b/libCacheSim/cache/eviction/ClockPro.c
@@ -189,7 +189,7 @@ static cache_obj_t *ClockPro_insert(cache_t *cache, const request_t *req) {
 
   cache_obj_t *obj = cache_insert_base(cache, req);
   obj->clockpro.referenced = params->init_ref;
-  obj->clockpro.status = COLD;
+  obj->clockpro.status = CLOCKPRO_COLD;
 
   if (params->hand_hot == NULL) { // Initial insertion
     prepend_obj_to_head(&params->hand_hot, &params->hand_hot, obj);
@@ -243,11 +243,11 @@ static void ClockPro_remove_obj(cache_t *cache, cache_obj_t *obj) {
   DEBUG_ASSERT(obj != NULL);
   cache_obj_t *hand_hot_prev = params->hand_hot->queue.prev;
 
-  if (obj->clockpro.status == TEST) {
+  if (obj->clockpro.status == CLOCKPRO_TEST) {
     params->mem_test -= obj->obj_size;
-  } else if (obj->clockpro.status == COLD) {
+  } else if (obj->clockpro.status == CLOCKPRO_COLD) {
     params->mem_cold -= obj->obj_size;
-  } else if (obj->clockpro.status == HOT) {
+  } else if (obj->clockpro.status == CLOCKPRO_HOT) {
     params->mem_hot -= obj->obj_size;
   }
 
@@ -298,7 +298,7 @@ static void ClockPro_run_test(cache_t *cache) {
   ClockPro_params_t *params = (ClockPro_params_t *)cache->eviction_params;
   cache_obj_t *obj = params->hand_test;
 
-  if (obj->clockpro.status != TEST) {
+  if (obj->clockpro.status != CLOCKPRO_TEST) {
     params->hand_test = obj->queue.next;
     return;
   }
@@ -331,7 +331,7 @@ static void ClockPro_run_cold(cache_t *cache) {
   ClockPro_params_t *params = (ClockPro_params_t *)cache->eviction_params;
   cache_obj_t *obj = params->hand_cold;
 
-  if (obj->clockpro.status != COLD) {
+  if (obj->clockpro.status != CLOCKPRO_COLD) {
     params->hand_cold = obj->queue.next;
     return;
   }
@@ -351,7 +351,7 @@ static void ClockPro_run_cold(cache_t *cache) {
   copy_cache_obj_to_request(&req, obj);
   cache_obj_t *demoted_obj = hashtable_insert(params->ht_test, &req);
   demoted_obj->clockpro.referenced = params->init_ref;
-  demoted_obj->clockpro.status = TEST;
+  demoted_obj->clockpro.status = CLOCKPRO_TEST;
 
   params->mem_test += obj->obj_size;
 
@@ -376,7 +376,7 @@ static void ClockPro_run_hot(cache_t *cache) {
   ClockPro_params_t *params = (ClockPro_params_t *)cache->eviction_params;
   cache_obj_t *obj = params->hand_hot;
 
-  if (obj->clockpro.status != HOT) {
+  if (obj->clockpro.status != CLOCKPRO_HOT) {
     params->hand_hot = obj->queue.next;
     return;
   }
@@ -391,7 +391,7 @@ static void ClockPro_run_hot(cache_t *cache) {
     ClockPro_run_cold(cache);
   }
 
-  obj->clockpro.status = COLD;
+  obj->clockpro.status = CLOCKPRO_COLD;
   obj->clockpro.referenced = params->init_ref;
 
   if (params->hand_cold == obj) {
@@ -412,7 +412,7 @@ static void ClockPro_run_hot(cache_t *cache) {
 static void ClockPro_promote(cache_t *cache, cache_obj_t *obj) {
   ClockPro_params_t *params = (ClockPro_params_t *)cache->eviction_params;
 
-  if (obj->clockpro.status == TEST) {
+  if (obj->clockpro.status == CLOCKPRO_TEST) {
     if (params->mem_cold_max + (int64_t)obj->obj_size > cache->cache_size) {
       params->mem_cold_max = cache->cache_size;
     } else {
@@ -432,7 +432,7 @@ static void ClockPro_promote(cache_t *cache, cache_obj_t *obj) {
   }
 
   clockpro_status_e old_status = obj->clockpro.status;
-  obj->clockpro.status = HOT;
+  obj->clockpro.status = CLOCKPRO_HOT;
   obj->clockpro.referenced = params->init_ref;
   cache_obj_t *hand_hot_next = params->hand_hot->queue.next;
   move_obj_to_tail(&hand_hot_next, &params->hand_hot, obj);
@@ -441,9 +441,9 @@ static void ClockPro_promote(cache_t *cache, cache_obj_t *obj) {
 
   params->hand_hot = obj->queue.next;
 
-  if (old_status == COLD) {
+  if (old_status == CLOCKPRO_COLD) {
     params->mem_cold -= obj->obj_size;
-  } else if (old_status == TEST) {
+  } else if (old_status == CLOCKPRO_TEST) {
     params->mem_test -= obj->obj_size;
   }
 

--- a/libCacheSim/include/libCacheSim/cacheObj.h
+++ b/libCacheSim/include/libCacheSim/cacheObj.h
@@ -10,7 +10,6 @@
 #include <stdio.h>
 
 #include "../config.h"
-#include "enum.h"
 #include "mem.h"
 
 #ifdef __cplusplus
@@ -25,6 +24,12 @@ typedef struct {
 typedef struct {
   int freq;
 } Clock_obj_metadata_t;
+
+typedef enum {
+  CLOCKPRO_TEST,
+  CLOCKPRO_COLD,
+  CLOCKPRO_HOT
+} clockpro_status_e;
 
 typedef struct {
   clockpro_status_e status;

--- a/libCacheSim/include/libCacheSim/cacheObj.h
+++ b/libCacheSim/include/libCacheSim/cacheObj.h
@@ -10,6 +10,7 @@
 #include <stdio.h>
 
 #include "../config.h"
+#include "enum.h"
 #include "mem.h"
 
 #ifdef __cplusplus
@@ -24,6 +25,11 @@ typedef struct {
 typedef struct {
   int freq;
 } Clock_obj_metadata_t;
+
+typedef struct {
+  clockpro_status_e status;
+  bool referenced;
+} ClockPro_obj_metadata_t;
 
 typedef struct {
   void *pq_node;
@@ -156,6 +162,7 @@ typedef struct cache_obj {
   union {
     LFU_obj_metadata_t lfu;          // for LFU
     Clock_obj_metadata_t clock;      // for Clock
+    ClockPro_obj_metadata_t clockpro;// for ClockPro
     Size_obj_metadata_t Size;        // for Size
     ARC_obj_metadata_t ARC;          // for ARC
     LeCaR_obj_metadata_t LeCaR;      // for LeCaR

--- a/libCacheSim/include/libCacheSim/enum.h
+++ b/libCacheSim/include/libCacheSim/enum.h
@@ -86,12 +86,6 @@ typedef enum {
   OP_INVALID = 255
 } req_op_e;
 
-typedef enum {
-  TEST,
-  COLD,
-  HOT
-} clockpro_status_e;
-
 static char *req_op_str[OP_INVALID + 2] = {"nop",     "get",    "gets", "set",  "add",  "cas",   "replace", "append",
                                            "prepend", "delete", "incr", "decr", "read", "write", "update",  "invalid"};
 

--- a/libCacheSim/include/libCacheSim/enum.h
+++ b/libCacheSim/include/libCacheSim/enum.h
@@ -86,6 +86,12 @@ typedef enum {
   OP_INVALID = 255
 } req_op_e;
 
+typedef enum {
+  TEST,
+  COLD,
+  HOT
+} clockpro_status_e;
+
 static char *req_op_str[OP_INVALID + 2] = {"nop",     "get",    "gets", "set",  "add",  "cas",   "replace", "append",
                                            "prepend", "delete", "incr", "decr", "read", "write", "update",  "invalid"};
 

--- a/libCacheSim/include/libCacheSim/evictionAlgo.h
+++ b/libCacheSim/include/libCacheSim/evictionAlgo.h
@@ -50,6 +50,8 @@ cache_t *Cacheus_init(const common_cache_params_t ccache_params, const char *cac
 
 cache_t *Clock_init(const common_cache_params_t ccache_params, const char *cache_specific_params);
 
+cache_t *ClockPro_init(const common_cache_params_t ccache_params, const char *cache_specific_params);
+
 cache_t *CR_LFU_init(const common_cache_params_t ccache_params, const char *cache_specific_params);
 
 cache_t *FIFO_init(const common_cache_params_t ccache_params, const char *cache_specific_params);

--- a/test/common.h
+++ b/test/common.h
@@ -204,6 +204,8 @@ static cache_t *create_test_cache(const char *alg_name, common_cache_params_t cc
     cache = FIFO_init(cc_params, NULL);
   } else if (strcasecmp(alg_name, "FIFO-Reinsertion") == 0 || strcasecmp(alg_name, "Clock") == 0) {
     cache = Clock_init(cc_params, NULL);
+  } else if (strcasecmp(alg_name, "ClockPro") == 0) {
+    cache = ClockPro_init(cc_params, NULL);
   } else if (strcasecmp(alg_name, "Belady") == 0) {
     cache = Belady_init(cc_params, NULL);
   } else if (strcasecmp(alg_name, "BeladySize") == 0) {

--- a/test/test_evictionAlgo.c
+++ b/test/test_evictionAlgo.c
@@ -495,32 +495,32 @@ int main(int argc, char *argv[]) {
 
   reader = setup_oracleGeneralBin_reader();
 
-  // g_test_add_data_func("/libCacheSim/cacheAlgo_Sieve", reader, test_Sieve);
-  // g_test_add_data_func("/libCacheSim/cacheAlgo_S3FIFO", reader, test_S3FIFO);
-  // g_test_add_data_func("/libCacheSim/cacheAlgo_S3FIFOv0", reader, test_S3FIFOv0);
-  // g_test_add_data_func("/libCacheSim/cacheAlgo_QDLP_FIFO", reader, test_QDLP_FIFO);
-  //
-  // g_test_add_data_func("/libCacheSim/cacheAlgo_LRU", reader, test_LRU);
-  // g_test_add_data_func("/libCacheSim/cacheAlgo_SLRU", reader, test_SLRU);
-  // g_test_add_data_func("/libCacheSim/cacheAlgo_ARC", reader, test_ARC);
-  // g_test_add_data_func("/libCacheSim/cacheAlgo_LeCaR", reader, test_LeCaR);
-  // g_test_add_data_func("/libCacheSim/cacheAlgo_SR_LRU", reader, test_SR_LRU);
-  // g_test_add_data_func("/libCacheSim/cacheAlgo_CR_LFU", reader, test_CR_LFU);
-  // g_test_add_data_func("/libCacheSim/cacheAlgo_Cacheus", reader, test_Cacheus);
-  // g_test_add_data_func("/libCacheSim/cacheAlgo_Hyperbolic", reader, test_Hyperbolic);
-  // g_test_add_data_func("/libCacheSim/cacheAlgo_LIRS", reader, test_LIRS);
+  g_test_add_data_func("/libCacheSim/cacheAlgo_Sieve", reader, test_Sieve);
+  g_test_add_data_func("/libCacheSim/cacheAlgo_S3FIFO", reader, test_S3FIFO);
+  g_test_add_data_func("/libCacheSim/cacheAlgo_S3FIFOv0", reader, test_S3FIFOv0);
+  g_test_add_data_func("/libCacheSim/cacheAlgo_QDLP_FIFO", reader, test_QDLP_FIFO);
 
-  // g_test_add_data_func("/libCacheSim/cacheAlgo_Clock", reader, test_Clock);
+  g_test_add_data_func("/libCacheSim/cacheAlgo_LRU", reader, test_LRU);
+  g_test_add_data_func("/libCacheSim/cacheAlgo_SLRU", reader, test_SLRU);
+  g_test_add_data_func("/libCacheSim/cacheAlgo_ARC", reader, test_ARC);
+  g_test_add_data_func("/libCacheSim/cacheAlgo_LeCaR", reader, test_LeCaR);
+  g_test_add_data_func("/libCacheSim/cacheAlgo_SR_LRU", reader, test_SR_LRU);
+  g_test_add_data_func("/libCacheSim/cacheAlgo_CR_LFU", reader, test_CR_LFU);
+  g_test_add_data_func("/libCacheSim/cacheAlgo_Cacheus", reader, test_Cacheus);
+  g_test_add_data_func("/libCacheSim/cacheAlgo_Hyperbolic", reader, test_Hyperbolic);
+  g_test_add_data_func("/libCacheSim/cacheAlgo_LIRS", reader, test_LIRS);
+
+  g_test_add_data_func("/libCacheSim/cacheAlgo_Clock", reader, test_Clock);
   g_test_add_data_func("/libCacheSim/cacheAlgo_ClockPro", reader, test_ClockPro);
-  // g_test_add_data_func("/libCacheSim/cacheAlgo_FIFO", reader, test_FIFO);
-  // g_test_add_data_func("/libCacheSim/cacheAlgo_MRU", reader, test_MRU);
-  // g_test_add_data_func("/libCacheSim/cacheAlgo_Random", reader, test_Random);
-  // g_test_add_data_func("/libCacheSim/cacheAlgo_LFU", reader, test_LFU);
-  // g_test_add_data_func("/libCacheSim/cacheAlgo_LFUDA", reader, test_LFUDA);
-  //
-  // g_test_add_data_func("/libCacheSim/cacheAlgo_LFUCpp", reader, test_LFUCpp);
-  // g_test_add_data_func("/libCacheSim/cacheAlgo_GDSF", reader, test_GDSF);
-  // g_test_add_data_func("/libCacheSim/cacheAlgo_LHD", reader, test_LHD);
+  g_test_add_data_func("/libCacheSim/cacheAlgo_FIFO", reader, test_FIFO);
+  g_test_add_data_func("/libCacheSim/cacheAlgo_MRU", reader, test_MRU);
+  g_test_add_data_func("/libCacheSim/cacheAlgo_Random", reader, test_Random);
+  g_test_add_data_func("/libCacheSim/cacheAlgo_LFU", reader, test_LFU);
+  g_test_add_data_func("/libCacheSim/cacheAlgo_LFUDA", reader, test_LFUDA);
+
+  g_test_add_data_func("/libCacheSim/cacheAlgo_LFUCpp", reader, test_LFUCpp);
+  g_test_add_data_func("/libCacheSim/cacheAlgo_GDSF", reader, test_GDSF);
+  g_test_add_data_func("/libCacheSim/cacheAlgo_LHD", reader, test_LHD);
 
   // /* Belady requires reader that has next access information and can only use
   //  * oracleGeneral trace */

--- a/test/test_evictionAlgo.c
+++ b/test/test_evictionAlgo.c
@@ -75,6 +75,24 @@ static void test_Clock(gconstpointer user_data) {
   my_free(sizeof(cache_stat_t), res);
 }
 
+static void test_ClockPro(gconstpointer user_data) {
+  uint64_t miss_cnt_true[] = {96390, 92614, 88911, 85894, 82276, 73203, 63728, 57544};
+  uint64_t miss_byte_true[] = {4163599360, 3922361856, 3700721152, 3491452416,
+                              3245322240, 2653708288, 2413087744, 2293678592};
+
+  reader_t *reader = (reader_t *)user_data;
+  common_cache_params_t cc_params = {.cache_size = CACHE_SIZE, .hashpower = 20, .default_ttl = DEFAULT_TTL};
+  cache_t *cache = create_test_cache("ClockPro", cc_params, reader, NULL);
+  g_assert_true(cache != NULL);
+  // cache_stat_t *res = simulate_at_multi_sizes_with_step_size(reader, cache, STEP_SIZE, NULL, 0, 0, _n_cores(), false);
+  cache_stat_t *res = simulate_at_multi_sizes_with_step_size(reader, cache, STEP_SIZE, NULL, 0, 0, _n_cores(), false);
+
+  print_results(cache, res);
+  _verify_profiler_results(res, CACHE_SIZE / STEP_SIZE, g_req_cnt_true, miss_cnt_true, g_req_byte_true, miss_byte_true);
+  cache->cache_free(cache);
+  my_free(sizeof(cache_stat_t), res);
+}
+
 static void test_FIFO(gconstpointer user_data) {
   uint64_t miss_cnt_true[] = {93403, 89386, 84387, 84025, 72498, 72228, 72182, 72140};
   uint64_t miss_byte_true[] = {4213112832, 4052646400, 3829170176, 3807412736,
@@ -477,31 +495,32 @@ int main(int argc, char *argv[]) {
 
   reader = setup_oracleGeneralBin_reader();
 
-  g_test_add_data_func("/libCacheSim/cacheAlgo_Sieve", reader, test_Sieve);
-  g_test_add_data_func("/libCacheSim/cacheAlgo_S3FIFO", reader, test_S3FIFO);
-  g_test_add_data_func("/libCacheSim/cacheAlgo_S3FIFOv0", reader, test_S3FIFOv0);
-  g_test_add_data_func("/libCacheSim/cacheAlgo_QDLP_FIFO", reader, test_QDLP_FIFO);
+  // g_test_add_data_func("/libCacheSim/cacheAlgo_Sieve", reader, test_Sieve);
+  // g_test_add_data_func("/libCacheSim/cacheAlgo_S3FIFO", reader, test_S3FIFO);
+  // g_test_add_data_func("/libCacheSim/cacheAlgo_S3FIFOv0", reader, test_S3FIFOv0);
+  // g_test_add_data_func("/libCacheSim/cacheAlgo_QDLP_FIFO", reader, test_QDLP_FIFO);
+  //
+  // g_test_add_data_func("/libCacheSim/cacheAlgo_LRU", reader, test_LRU);
+  // g_test_add_data_func("/libCacheSim/cacheAlgo_SLRU", reader, test_SLRU);
+  // g_test_add_data_func("/libCacheSim/cacheAlgo_ARC", reader, test_ARC);
+  // g_test_add_data_func("/libCacheSim/cacheAlgo_LeCaR", reader, test_LeCaR);
+  // g_test_add_data_func("/libCacheSim/cacheAlgo_SR_LRU", reader, test_SR_LRU);
+  // g_test_add_data_func("/libCacheSim/cacheAlgo_CR_LFU", reader, test_CR_LFU);
+  // g_test_add_data_func("/libCacheSim/cacheAlgo_Cacheus", reader, test_Cacheus);
+  // g_test_add_data_func("/libCacheSim/cacheAlgo_Hyperbolic", reader, test_Hyperbolic);
+  // g_test_add_data_func("/libCacheSim/cacheAlgo_LIRS", reader, test_LIRS);
 
-  g_test_add_data_func("/libCacheSim/cacheAlgo_LRU", reader, test_LRU);
-  g_test_add_data_func("/libCacheSim/cacheAlgo_SLRU", reader, test_SLRU);
-  g_test_add_data_func("/libCacheSim/cacheAlgo_ARC", reader, test_ARC);
-  g_test_add_data_func("/libCacheSim/cacheAlgo_LeCaR", reader, test_LeCaR);
-  g_test_add_data_func("/libCacheSim/cacheAlgo_SR_LRU", reader, test_SR_LRU);
-  g_test_add_data_func("/libCacheSim/cacheAlgo_CR_LFU", reader, test_CR_LFU);
-  g_test_add_data_func("/libCacheSim/cacheAlgo_Cacheus", reader, test_Cacheus);
-  g_test_add_data_func("/libCacheSim/cacheAlgo_Hyperbolic", reader, test_Hyperbolic);
-  g_test_add_data_func("/libCacheSim/cacheAlgo_LIRS", reader, test_LIRS);
-
-  g_test_add_data_func("/libCacheSim/cacheAlgo_Clock", reader, test_Clock);
-  g_test_add_data_func("/libCacheSim/cacheAlgo_FIFO", reader, test_FIFO);
-  g_test_add_data_func("/libCacheSim/cacheAlgo_MRU", reader, test_MRU);
-  g_test_add_data_func("/libCacheSim/cacheAlgo_Random", reader, test_Random);
-  g_test_add_data_func("/libCacheSim/cacheAlgo_LFU", reader, test_LFU);
-  g_test_add_data_func("/libCacheSim/cacheAlgo_LFUDA", reader, test_LFUDA);
-
-  g_test_add_data_func("/libCacheSim/cacheAlgo_LFUCpp", reader, test_LFUCpp);
-  g_test_add_data_func("/libCacheSim/cacheAlgo_GDSF", reader, test_GDSF);
-  g_test_add_data_func("/libCacheSim/cacheAlgo_LHD", reader, test_LHD);
+  // g_test_add_data_func("/libCacheSim/cacheAlgo_Clock", reader, test_Clock);
+  g_test_add_data_func("/libCacheSim/cacheAlgo_ClockPro", reader, test_ClockPro);
+  // g_test_add_data_func("/libCacheSim/cacheAlgo_FIFO", reader, test_FIFO);
+  // g_test_add_data_func("/libCacheSim/cacheAlgo_MRU", reader, test_MRU);
+  // g_test_add_data_func("/libCacheSim/cacheAlgo_Random", reader, test_Random);
+  // g_test_add_data_func("/libCacheSim/cacheAlgo_LFU", reader, test_LFU);
+  // g_test_add_data_func("/libCacheSim/cacheAlgo_LFUDA", reader, test_LFUDA);
+  //
+  // g_test_add_data_func("/libCacheSim/cacheAlgo_LFUCpp", reader, test_LFUCpp);
+  // g_test_add_data_func("/libCacheSim/cacheAlgo_GDSF", reader, test_GDSF);
+  // g_test_add_data_func("/libCacheSim/cacheAlgo_LHD", reader, test_LHD);
 
   // /* Belady requires reader that has next access information and can only use
   //  * oracleGeneral trace */


### PR DESCRIPTION
#86 

I have validated the miss ratio against the existing CLOCK implementation in libCacheSim by comparing miss_cnt_true and miss_byte_true in the test_evictionAlgo.c file. Additionally, a quick verification is done using the cloudPhysicsIO.vscsi trace. The results show that while CLOCK-Pro has a slightly higher miss ratio at smaller cache sizes, it achieves a lower miss ratio than CLOCK as the cache size increases.
Below is a summary of the results:

```
$ ./bin/cachesim ../data/cloudPhysicsIO.vscsi vscsi clock 128mb,256mb,512mb,1gb,2gb
../data/cloudPhysicsIO.vscsi Clock cache size      128MiB, 113872 req, miss ratio 0.8174, byte miss ratio 0.9594
../data/cloudPhysicsIO.vscsi Clock cache size      256MiB, 113872 req, miss ratio 0.7715, byte miss ratio 0.9140
../data/cloudPhysicsIO.vscsi Clock cache size      512MiB, 113872 req, miss ratio 0.7135, byte miss ratio 0.8558
../data/cloudPhysicsIO.vscsi Clock cache size     1024MiB, 113872 req, miss ratio 0.5660, byte miss ratio 0.6407
../data/cloudPhysicsIO.vscsi Clock cache size     2048MiB, 113872 req, miss ratio 0.4301, byte miss ratio 0.4826

$ ./bin/cachesim ../data/cloudPhysicsIO.vscsi vscsi clockpro 128mb,256mb,512mb,1gb,2gb
../data/cloudPhysicsIO.vscsi ClockPro cache size      128MiB, 113872 req, miss ratio 0.8465, byte miss ratio 0.9462
../data/cloudPhysicsIO.vscsi ClockPro cache size      256MiB, 113872 req, miss ratio 0.8133, byte miss ratio 0.8889
../data/cloudPhysicsIO.vscsi ClockPro cache size      512MiB, 113872 req, miss ratio 0.7543, byte miss ratio 0.7993
../data/cloudPhysicsIO.vscsi ClockPro cache size     1024MiB, 113872 req, miss ratio 0.5053, byte miss ratio 0.5478
../data/cloudPhysicsIO.vscsi ClockPro cache size     2048MiB, 113872 req, miss ratio 0.4301, byte miss ratio 0.4826
```

Comparison against open-source implementations of ClockPro such as [PyClockPro](https://bitbucket.org/SamiLehtinen/pyclockpro/src/master/) was also done with the summary shown below (rounded to fourth decimal place):
|Size|This Implementation|PyClockPro|
|---|---|---|
|4897|0.8363|0.7420|
|9794|0.7662|0.7076|
|14692|0.6435|0.6214|
|19589|0.5670|0.5848|
|24487|0.5092|0.5654|
|29384|0.4955|0.5653|
|34281|0.4726|0.5646|
|39179|0.4574|0.5049|
|44076|0.4384|0.4302|
|48974|0.4301|0.4301|

PyClockPro was chosen as the open-source implementation comparator since it is referenced by most open-source implementation such as [go-clockpro](https://github.com/dgryski/go-clockpro) and [rust-clockpro-cache](https://github.com/jedisct1/rust-clockpro-cache).

There is a different interpretation of the clock hand movement in PyClockPro compared to [the reference used](https://blog.yufeng.info/wp-content/uploads/2010/08/8-Clock-Pro.pdf). In PyClockPro, the hand moves first before checking the object it points to. Meanwhile, the reference I used checks the object pointed by the hand first before moving the hand.