### PR TITLE
fix header guard

### DIFF
--- a/libCacheSim/cache/admission/adaptsize/adaptsize.h
+++ b/libCacheSim/cache/admission/adaptsize/adaptsize.h
@@ -1,4 +1,5 @@
 #ifndef LIBCACHESIM_ADMISSION_ADAPTSIZE_H
+#define LIBCACHESIM_ADMISSION_ADAPTSIZE_H
 
 #include "../../include/libCacheSim/request.h"
 #include <unordered_map>


### PR DESCRIPTION
Added define clause as part of header guard. It is unlikely to be included by others, as this file is specific to AdaptSize. This was done just in case.