### PR TITLE
[minor]: Ubuntu uname returns "Linux"

### DIFF
--- a/scripts/install_dependency.sh
+++ b/scripts/install_dependency.sh
@@ -80,7 +80,7 @@ install_zstd() {
 
 CURR_DIR=$(pwd)
 
-if [ -n "$(uname -a | grep Ubuntu)" ] || [ -n "$(uname -a | grep Debian)" ] || [ -n "$(uname -a | grep WSL)" ]; then
+if [ -n "$(uname -a | grep Ubuntu)" ] || [ -n "$(uname -a | grep Debian)" ] || [ -n "$(uname -a | grep WSL)" ] || [ -n "$(uname -a | grep Linux)" ]; then
     setup_ubuntu
 elif [ -n "$(uname -a | grep Darwin)" ]; then
     setup_macOS


### PR DESCRIPTION
Was working with libCacheSim and realized that the _uname_ command returns GNU/Linux on Ubuntu 22.04. Without this modification to the installation script one cannot install on Ubuntu OS.