### PR TITLE
Cacheus Fix: Carry Over of the SR_LRU.new_obj Flag

### DIFF
--- a/libCacheSim/cache/eviction/SR_LRU.c
+++ b/libCacheSim/cache/eviction/SR_LRU.c
@@ -238,6 +238,9 @@ static cache_obj_t *SR_LRU_insert(cache_t *cache, const request_t *req) {
 
   // If history hit
   if (ck_hist) {
+    // Used to carry-over the new_obj flag
+    bool was_new = H->find(H, req, false)->SR_LRU.new_obj;
+
     // On a cache miss where x is in H, x is moved to the MRU position of R.
     H->remove(H, req->obj_id);
 
@@ -261,6 +264,7 @@ static cache_obj_t *SR_LRU_insert(cache_t *cache, const request_t *req) {
 
     R->insert(R, req);
     obj = R->find(R, req, false);
+    obj->SR_LRU.new_obj = was_new;
 
     // Dynamic size adjustment
     // If an obj is moved from H to R

--- a/libCacheSim/include/libCacheSim/request.h
+++ b/libCacheSim/include/libCacheSim/request.h
@@ -116,11 +116,11 @@ static inline void free_request(request_t *req) { my_free(request_t, req); }
 
 static inline void print_request(const request_t *req) {
 #ifdef SUPPORT_TTL
-  LOGGING(DEBUG_LEVEL, "req clcok_time %lu, id %llu, size %ld, ttl %ld, op %s, valid %d\n",
+  LOGGING(DEBUG_LEVEL, "req clock_time %lu, id %llu, size %ld, ttl %ld, op %s, valid %d\n",
           (unsigned long)req->clock_time, (unsigned long long)req->obj_id, (long)req->obj_size, (long)req->ttl,
           req_op_str[req->op], req->valid);
 #else
-  LOGGING(DEBUG_LEVEL, "req clcok_time %lu, id %llu, size %ld, op %s, valid %d\n", (unsigned long)req->clock_time,
+  LOGGING(DEBUG_LEVEL, "req clock_time %lu, id %llu, size %ld, op %s, valid %d\n", (unsigned long)req->clock_time,
           (unsigned long long)req->obj_id, (long)req->obj_size, req_op_str[req->op], req->valid);
 #endif
 }

--- a/test/test_evictionAlgo.c
+++ b/test/test_evictionAlgo.c
@@ -272,9 +272,9 @@ static void test_LeCaR(gconstpointer user_data) {
 }
 
 static void test_Cacheus(gconstpointer user_data) {
-  uint64_t miss_cnt_true[] = {89328, 82377, 80079, 77111, 69654, 69492, 69165, 66072};
-  uint64_t miss_byte_true[] = {4025448960, 3727429632, 3554795008, 3359375872,
-                               3003613696, 2964137472, 2928446976, 2790086656};
+  uint64_t miss_cnt_true[] = {89776, 82725, 78839, 73048, 69329, 69184, 69117, 66048};
+  uint64_t miss_byte_true[] = {4048868864, 3727920128, 3489738752, 3184179200,
+                               2981198336, 2968055296, 2925565440, 2789046784};
 
   reader_t *reader = (reader_t *)user_data;
   common_cache_params_t cc_params = {.cache_size = CACHE_SIZE, .hashpower = 20, .default_ttl = DEFAULT_TTL};
@@ -289,9 +289,9 @@ static void test_Cacheus(gconstpointer user_data) {
 }
 
 static void test_SR_LRU(gconstpointer user_data) {
-  uint64_t miss_cnt_true[] = {90043, 83978, 81481, 77724, 72611, 72058, 67837, 65739};
-  uint64_t miss_byte_true[] = {4068758016, 3792818176, 3639694848, 3379471872,
-                               3165339648, 3058749440, 2862783488, 2774183936};
+  uint64_t miss_cnt_true[] = {90043, 83978, 81482, 77727, 72611, 72059, 67836, 65739};
+  uint64_t miss_byte_true[] = {4068758016, 3792818176, 3639756288, 3379609600,
+                               3165339648, 3058814976, 2862775296, 2774183936};
 
   reader_t *reader = (reader_t *)user_data;
   common_cache_params_t cc_params = {.cache_size = CACHE_SIZE, .hashpower = 20, .default_ttl = DEFAULT_TTL};


### PR DESCRIPTION
I discovered a bug in how the SR_LRU.new_obj metadata flag is handled during object movement from the history list to the churn resistant list. This minor bug caused the dynamic size adjustment of the scan resistant list to never be triggered.

The issue became apparent when I ran Cacheus with the --ignore-obj-size=1 flag and observed that the cache failed to evict any objects. Upon investigation with a logger, I found that the problem was caused by the LRU list used by Cacheus, which encountered issues when inserting the last object before the cache reached full capacity.

Additionally, I fixed a minor typo in the logging output. The typo 'clcok_time' was corrected to 'clock_time'

Changes:
* Corrected the handling of the SR_LRU.new_obj flag to ensure proper size adjustments for the SR list
* Fixed the typo in debug logging: changed 'clcok_time' to 'clock_time'
* Test Cases for eviction algorithms has already been modified as well to accommodate the change in SR_LRU cache