### PR TITLE
Refactor cache name

### DIFF
--- a/libCacheSim/bin/cachesim/sim.c
+++ b/libCacheSim/bin/cachesim/sim.c
@@ -29,8 +29,8 @@ void simulate(reader_t *reader, cache_t *cache, int report_interval, int warmup_
   uint64_t start_ts = (uint64_t)req->clock_time;
   uint64_t last_report_ts = warmup_sec;
 
-  char cache_stat_name[CACHE_STAT_NAME_ARRAY_LEN];
-  generate_cache_name(cache, cache_stat_name);
+  char detailed_cache_name[256];
+  generate_cache_name(cache, detailed_cache_name, 256);
 
   double start_time = -1;
   while (req->valid) {
@@ -61,7 +61,7 @@ void simulate(reader_t *reader, cache_t *cache, int report_interval, int warmup_
           "%s %s %.2lf hour: %lu requests, miss ratio %.4lf, interval miss "
           "ratio "
           "%.4lf\n",
-          mybasename(reader->trace_path), cache_stat_name,
+          mybasename(reader->trace_path), detailed_cache_name,
           (double)req->clock_time / 3600, (unsigned long)req_cnt,
           (double)miss_cnt / req_cnt,
           (double)(miss_cnt - last_miss_cnt) / (req_cnt - last_req_cnt));
@@ -88,14 +88,14 @@ void simulate(reader_t *reader, cache_t *cache, int report_interval, int warmup_
     snprintf(output_str, 1024,
              "%s %s cache size %8s, %16lu req, miss ratio %.4lf, throughput "
              "%.2lf MQPS\n",
-            reader->trace_path, cache_stat_name, size_str,
+            reader->trace_path, detailed_cache_name, size_str,
             (unsigned long)req_cnt, (double)miss_cnt / (double)req_cnt,
             (double)req_cnt / 1000000.0 / runtime);
   } else {
     snprintf(output_str, 1024,
              "%s %s cache size %8ld, %16lu req, miss ratio %.4lf, throughput "
              "%.2lf MQPS\n",
-            reader->trace_path, cache_stat_name, cache->cache_size,
+            reader->trace_path, detailed_cache_name, cache->cache_size,
             (unsigned long)req_cnt, (double)miss_cnt / (double)req_cnt,
             (double)req_cnt / 1000000.0 / runtime);
   }

--- a/libCacheSim/include/libCacheSim/admissionAlgo.h
+++ b/libCacheSim/include/libCacheSim/admissionAlgo.h
@@ -20,7 +20,7 @@ typedef struct admissioner {
   admissioner_clone_func_ptr clone;
   admissioner_free_func_ptr free;
   admissioner_update_func_ptr update;
-  void *init_params;
+  char *init_params;
   char admissioner_name[CACHE_NAME_LEN];
 } admissioner_t;
 

--- a/libCacheSim/include/libCacheSim/prefetchAlgo.h
+++ b/libCacheSim/include/libCacheSim/prefetchAlgo.h
@@ -11,34 +11,32 @@ extern "C" {
 #endif
 
 struct prefetcher;
+struct cache;
 typedef struct prefetcher *(*prefetcher_create_func_ptr)(const char *);
-typedef void (*prefetcher_prefetch_func_ptr)(cache_t *, const request_t *);
-typedef void (*prefetcher_handle_find_func_ptr)(cache_t *, const request_t *,
-                                                bool);
-typedef void (*prefetcher_handle_insert_func_ptr)(cache_t *, const request_t *);
-typedef void (*prefetcher_handle_evict_func_ptr)(cache_t *, const request_t *);
+typedef void (*prefetcher_prefetch_func_ptr)(struct cache *, const request_t *);
+typedef void (*prefetcher_handle_find_func_ptr)(struct cache *, const request_t *, bool);
+typedef void (*prefetcher_handle_insert_func_ptr)(struct cache *, const request_t *);
+typedef void (*prefetcher_handle_evict_func_ptr)(struct cache *, const request_t *);
 typedef void (*prefetcher_free_func_ptr)(struct prefetcher *);
-typedef struct prefetcher *(*prefetcher_clone_func_ptr)(struct prefetcher *,
-                                                        uint64_t);
+typedef struct prefetcher *(*prefetcher_clone_func_ptr)(struct prefetcher *, uint64_t);
 
 typedef struct prefetcher {
-  void *params;
-  void *init_params;
   prefetcher_prefetch_func_ptr prefetch;
   prefetcher_handle_find_func_ptr handle_find;
   prefetcher_handle_insert_func_ptr handle_insert;
   prefetcher_handle_evict_func_ptr handle_evict;
   prefetcher_free_func_ptr free;
   prefetcher_clone_func_ptr clone;
+  void *params;
+  char *init_params;
+  char prefetcher_name[64];
 } prefetcher_t;
 
-prefetcher_t *create_Mithril_prefetcher(const char *init_paramsm,
-                                        uint64_t cache_size);
+prefetcher_t *create_Mithril_prefetcher(const char *init_paramsm, uint64_t cache_size);
 prefetcher_t *create_OBL_prefetcher(const char *init_paramsm, uint64_t cache_size);
 prefetcher_t *create_PG_prefetcher(const char *init_paramsm, uint64_t cache_size);
 
-static inline prefetcher_t *create_prefetcher(const char *prefetching_algo,
-                                              const char *prefetching_params,
+static inline prefetcher_t *create_prefetcher(const char *prefetching_algo, const char *prefetching_params,
                                               uint64_t cache_size) {
   prefetcher_t *prefetcher = NULL;
   if (strcasecmp(prefetching_algo, "Mithril") == 0) {

--- a/libCacheSim/profiler/simulator.c
+++ b/libCacheSim/profiler/simulator.c
@@ -124,7 +124,6 @@ static void _simulate(gpointer data, gpointer user_data) {
   result[idx].curr_rtime = req->clock_time;
   result[idx].n_obj = local_cache->n_obj;
   result[idx].occupied_byte = local_cache->occupied_byte;
-  generate_cache_name(local_cache, result[idx].cache_name);
 
   // report progress
   g_mutex_lock(&(params->mtx));

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -1,4 +1,5 @@
 #!/bin/bash 
+set -euo pipefail
 
 SOURCE=$(readlink -f ${BASH_SOURCE[0]})
 SCRIPT_DIR=$(dirname ${SOURCE})
@@ -28,6 +29,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         -c|--clean)
             CLEAN=1
+            shift
+            ;;
+        -d|--default)
+            PROGRAM_ARGS=("data/cloudPhysicsIO.vscsi" "vscsi" "lru,s3fifo" "100m,1gb")
             shift
             ;;
         --)


### PR DESCRIPTION
- Updated `generate_cache_name` function to accept a destination buffer and its length, allowing for more detailed cache names.
- Refactored `cache_struct_init` and related functions for better readability and consistency.
- Changed `init_params` in `admissioner_t` and `prefetcher_t` structures from `void*` to `char*` for clarity.
- Cleaned up function signatures and formatting across multiple files for improved code quality.