### PR TITLE
Remove redundant decls

### DIFF
--- a/libCacheSim/cache/admission/adaptsize/adaptsize_interface.cpp
+++ b/libCacheSim/cache/admission/adaptsize/adaptsize_interface.cpp
@@ -25,7 +25,8 @@ static const char *DEFAULT_PARAMS = "max-iteration=15,reconf-interval=30000";
 // ***********************************************************************
 void free_adaptsize_admissioner(admissioner_t *admissioner);
 admissioner_t *clone_adaptsize_admissioner(admissioner_t *admissioner);
-// admissioner_t *create_adaptsize_admissioner(const char *init_params); // declared in admissionAlgo.h
+// declared in admissionAlgo.h
+// admissioner_t *create_adaptsize_admissioner(const char *init_params);
 void adaptsize_update_stats(admissioner_t *admissioner, const request_t *req,
                             const uint64_t cache_size);
 bool adaptsize_admit(admissioner_t *admissioner, const request_t *req);

--- a/libCacheSim/cache/admission/adaptsize/adaptsize_interface.cpp
+++ b/libCacheSim/cache/admission/adaptsize/adaptsize_interface.cpp
@@ -25,7 +25,7 @@ static const char *DEFAULT_PARAMS = "max-iteration=15,reconf-interval=30000";
 // ***********************************************************************
 void free_adaptsize_admissioner(admissioner_t *admissioner);
 admissioner_t *clone_adaptsize_admissioner(admissioner_t *admissioner);
-admissioner_t *create_adaptsize_admissioner(const char *init_params);
+// admissioner_t *create_adaptsize_admissioner(const char *init_params); // declared in admissionAlgo.h
 void adaptsize_update_stats(admissioner_t *admissioner, const request_t *req,
                             const uint64_t cache_size);
 bool adaptsize_admit(admissioner_t *admissioner, const request_t *req);


### PR DESCRIPTION
Since `-Wredundant-decls` is enabled, we get error msg like
```
libCacheSim/cache/admission/adaptsize/adaptsize_interface.cpp:28:23: error: redundant redeclaration of ‘admissioner_t* create_adaptsize_admissioner(const char*)’ in same scope [-Werror=redundant-decls]
   28 | extern admissioner_t *create_adaptsize_admissioner(const char *init_params); // declared in admissionAlgo.h
   
libCacheSim/cache/admission/adaptsize/adaptsize_interface.cpp:6:
libCacheSim/cache/admission/../../include/libCacheSim/admissionAlgo.h:31:16: note: previous declaration of ‘admissioner_t* create_adaptsize_admissioner(const char*)’
   31 | admissioner_t *create_adaptsize_admissioner(const char *init_params);
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```