### PR TITLE
Replace clang-tidy dependency with llvm for macOS

### DIFF
--- a/scripts/install_dependency.sh
+++ b/scripts/install_dependency.sh
@@ -130,7 +130,7 @@ setup_macOS() {
         log_error "Homebrew is not installed. Please install Homebrew first."
         exit 1
     fi
-    brew install glib google-perftools argp-standalone xxhash clang-tidy
+    brew install glib google-perftools argp-standalone xxhash llvm
 }
 
 # Install CMake


### PR DESCRIPTION
Addresses issue #178. 

**TLDR**;  `clang-tidy` is unavailable on macOS but is provided by the `llvm` package, so is replaced.