### PR TITLE
[refactor]: simplify logging

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,10 +1,6 @@
 name: Code Quality
 
-on:
-  push:
-    branches: [ main, master, develop ]
-  pull_request:
-    branches: [ main, master, develop ]
+on: [push, pull_request]
 
 jobs:
   code-quality:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,8 @@ option(SUPPORT_TTL "whether support TTL" OFF)
 option(OPT_SUPPORT_ZSTD_TRACE "whether support zstd trace" ON)
 option(ENABLE_LRB "enable LRB" OFF)
 option(ENABLE_3L_CACHE "enable 3LCache" OFF)
-set(LOG_LEVEL NONE CACHE STRING "change the logging level")
-set_property(CACHE LOG_LEVEL PROPERTY STRINGS ERROR WARN INFO DEBUG VERBOSE)
+set(LOG_LEVEL "default" CACHE STRING "change the logging level")
+set_property(CACHE LOG_LEVEL PROPERTY STRINGS ERROR WARN INFO DEBUG VERBOSE DEFAULT)
 
 # Platform detection
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
@@ -51,9 +51,15 @@ if(USE_HUGEPAGE)
     add_compile_definitions(USE_HUGEPAGE=1)
 endif()
 
+if(NOT CMAKE_BUILD_TYPE)
+    # we can also consider RelWithDebInfo, but it will be too slow for release build
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+
 string(TOLOWER "${LOG_LEVEL}" LOG_LEVEL_LOWER)
 
-if(LOG_LEVEL_LOWER STREQUAL "none")
+if(LOG_LEVEL_LOWER STREQUAL "default")
     if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
         message(STATUS "LOG_LEVEL is not set, use DEBUG as default for debug build")
         add_compile_definitions(LOGLEVEL=6)
@@ -76,11 +82,6 @@ else()
     add_compile_definitions(LOGLEVEL=7)
 endif()
 
-
-if(NOT CMAKE_BUILD_TYPE)
-    # we can also consider RelWithDebInfo, but it will be too slow for release build
-    set(CMAKE_BUILD_TYPE Release)
-endif()
 
 
 # Define shared compiler flags for all targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,9 +58,10 @@ endif()
 
 
 string(TOLOWER "${LOG_LEVEL}" LOG_LEVEL_LOWER)
+string(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_LOWER)
 
 if(LOG_LEVEL_LOWER STREQUAL "default")
-    if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
+    if(CMAKE_BUILD_TYPE_LOWER MATCHES "Debug")
         message(STATUS "LOG_LEVEL is not set, use DEBUG as default for debug build")
         add_compile_definitions(LOGLEVEL=6)
     else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ option(OPT_SUPPORT_ZSTD_TRACE "whether support zstd trace" ON)
 option(ENABLE_LRB "enable LRB" OFF)
 option(ENABLE_3L_CACHE "enable 3LCache" OFF)
 set(LOG_LEVEL NONE CACHE STRING "change the logging level")
-set_property(CACHE LOG_LEVEL PROPERTY STRINGS VERBOSE DEBUG INFO WARN ERROR)
+set_property(CACHE LOG_LEVEL PROPERTY STRINGS ERROR WARN INFO DEBUG VERBOSE)
 
 # Platform detection
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,20 +41,6 @@ else()
     message(FATAL_ERROR "unsupported operating system ${CMAKE_SYSTEM_NAME}")
 endif()
 
-if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE Release)
-
-    if(LOG_LEVEL STREQUAL "NONE")
-        set(LOG_LEVEL INFO)
-    endif()
-elseif(${CMAKE_BUILD_TYPE} MATCHES "Debug")
-    if(LOG_LEVEL STREQUAL "NONE")
-        set(LOG_LEVEL DEBUG)
-    endif()
-else()
-    set(LOG_LEVEL INFO)
-endif()
-
 configure_file(libCacheSim/include/config.h.in libCacheSim/include/config.h)
 
 if(SUPPORT_TTL)
@@ -67,7 +53,15 @@ endif()
 
 string(TOLOWER "${LOG_LEVEL}" LOG_LEVEL_LOWER)
 
-if(LOG_LEVEL_LOWER STREQUAL "verbose")
+if(LOG_LEVEL_LOWER STREQUAL "")
+    if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
+        message(STATUS "LOG_LEVEL is not set, use DEBUG as default for debug build")
+        add_compile_definitions(LOGLEVEL=6)
+    else()
+        message(STATUS "LOG_LEVEL is not set, use INFO as default for release build")
+        add_compile_definitions(LOGLEVEL=7)
+    endif()
+elseif(LOG_LEVEL_LOWER STREQUAL "verbose")
     add_compile_definitions(LOGLEVEL=5)
 elseif(LOG_LEVEL_LOWER STREQUAL "debug")
     add_compile_definitions(LOGLEVEL=6)
@@ -77,14 +71,17 @@ elseif(LOG_LEVEL_LOWER STREQUAL "warn")
     add_compile_definitions(LOGLEVEL=8)
 elseif(LOG_LEVEL_LOWER STREQUAL "error")
     add_compile_definitions(LOGLEVEL=9)
-
-# default none is info
-elseif(LOG_LEVEL_LOWER STREQUAL "none")
-    add_compile_definitions(LOGLEVEL=7)
 else()
     message(WARNING "unknown log level ${LOG_LEVEL}, use INFO as default")
     add_compile_definitions(LOGLEVEL=7)
 endif()
+
+
+if(NOT CMAKE_BUILD_TYPE)
+    # we can also consider RelWithDebInfo, but it will be too slow for release build
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
 
 # Define shared compiler flags for all targets
 set(LIBCACHESIM_C_FLAGS 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ option(OPT_SUPPORT_ZSTD_TRACE "whether support zstd trace" ON)
 option(ENABLE_LRB "enable LRB" OFF)
 option(ENABLE_3L_CACHE "enable 3LCache" OFF)
 set(LOG_LEVEL NONE CACHE STRING "change the logging level")
-set_property(CACHE LOG_LEVEL PROPERTY STRINGS INFO WARN ERROR DEBUG VERBOSE VVERBOSE VVVERBOSE)
+set_property(CACHE LOG_LEVEL PROPERTY STRINGS VERBOSE DEBUG INFO WARN ERROR)
 
 # Platform detection
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
@@ -67,11 +67,7 @@ endif()
 
 string(TOLOWER "${LOG_LEVEL}" LOG_LEVEL_LOWER)
 
-if(LOG_LEVEL_LOWER STREQUAL "vvverbose")
-    add_compile_definitions(LOGLEVEL=3)
-elseif(LOG_LEVEL_LOWER STREQUAL "vverbose")
-    add_compile_definitions(LOGLEVEL=4)
-elseif(LOG_LEVEL_LOWER STREQUAL "verbose")
+if(LOG_LEVEL_LOWER STREQUAL "verbose")
     add_compile_definitions(LOGLEVEL=5)
 elseif(LOG_LEVEL_LOWER STREQUAL "debug")
     add_compile_definitions(LOGLEVEL=6)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ endif()
 
 string(TOLOWER "${LOG_LEVEL}" LOG_LEVEL_LOWER)
 
-if(LOG_LEVEL_LOWER STREQUAL "")
+if(LOG_LEVEL_LOWER STREQUAL "none")
     if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
         message(STATUS "LOG_LEVEL is not set, use DEBUG as default for debug build")
         add_compile_definitions(LOGLEVEL=6)

--- a/libCacheSim/cache/admission/adaptsize/adaptsize.cpp
+++ b/libCacheSim/cache/admission/adaptsize/adaptsize.cpp
@@ -188,7 +188,7 @@ void Adaptsize::reconfigure() {
     total_obj_size += it->second.obj_size;
     ++it;
   }
-  VVERBOSE(
+  VERBOSE(
       "Reconfiguring over %zu objects - log2 total size %f log2 statsize %f\n",
       longterm_metadata.size(), log2(total_obj_size), log2(stat_size));
   // END Prepare for reconf
@@ -249,10 +249,10 @@ void Adaptsize::reconfigure() {
     WARN("BUG: NaN h1:%f h2:%f\n", h1, h2);
   } else if (h1 > h2) {
     c_param = pow(2, x1);
-    VVERBOSE("C = %f (log2: %f )\n", c_param, x1);
+    VERBOSE("C = %f (log2: %f )\n", c_param, x1);
   } else {
     c_param = pow(2, x2);
-    VVERBOSE("C = %f (log2: %f )\n", c_param, x2);
+    VERBOSE("C = %f (log2: %f )\n", c_param, x2);
   }
   // END Check for result
 }

--- a/libCacheSim/cache/cache.c
+++ b/libCacheSim/cache/cache.c
@@ -243,10 +243,10 @@ bool cache_get_base(cache_t *cache, const request_t *req) {
   }
 
   if (hit) {
-    VVERBOSE("req %ld, obj %ld --- cache hit\n", cache->n_req, req->obj_id);
+    VERBOSE("req %ld, obj %ld --- cache hit\n", cache->n_req, req->obj_id);
   } else if (!cache->can_insert(cache, req)) {
-    VVERBOSE("req %ld, obj %ld --- cache miss cannot insert\n", cache->n_req,
-             req->obj_id);
+    VERBOSE("req %ld, obj %ld --- cache miss cannot insert\n", cache->n_req,
+            req->obj_id);
   } else {
     while (cache->get_occupied_byte(cache) + req->obj_size +
                cache->obj_md_size >

--- a/libCacheSim/cache/eviction/GLCache/GLCache.c
+++ b/libCacheSim/cache/eviction/GLCache/GLCache.c
@@ -397,7 +397,7 @@ static cache_obj_t *GLCache_insert(cache_t *cache, const request_t *req) {
 
     seg = allocate_new_seg(cache, bucket->bucket_id);
     append_seg_to_bucket(params, bucket, seg);
-    VVERBOSE("%lu allocate new seg, %d in use seg\n", cache->n_req,
+    VERBOSE("%lu allocate new seg, %d in use seg\n", cache->n_req,
              params->n_in_use_segs);
   }
 

--- a/libCacheSim/cache/eviction/GLCache/GLCache.c
+++ b/libCacheSim/cache/eviction/GLCache/GLCache.c
@@ -398,7 +398,7 @@ static cache_obj_t *GLCache_insert(cache_t *cache, const request_t *req) {
     seg = allocate_new_seg(cache, bucket->bucket_id);
     append_seg_to_bucket(params, bucket, seg);
     VERBOSE("%lu allocate new seg, %d in use seg\n", cache->n_req,
-             params->n_in_use_segs);
+            params->n_in_use_segs);
   }
 
   cache_obj_t *cache_obj = &seg->objs[seg->n_obj];

--- a/libCacheSim/cache/eviction/GLCache/eviction.c
+++ b/libCacheSim/cache/eviction/GLCache/eviction.c
@@ -142,7 +142,7 @@ void GLCache_merge_segs(cache_t *cache, bucket_t *bucket, segment_t **segs) {
 // different from clean_one_seg because this function also updates cache state
 int evict_one_seg(cache_t *cache, segment_t *seg) {
   VERBOSE("req %lu, evict one seg id %d occupied size %lu/%lu\n", cache->n_req,
-           seg->seg_id, cache->occupied_byte, cache->cache_size);
+          seg->seg_id, cache->occupied_byte, cache->cache_size);
   GLCache_params_t *params = cache->eviction_params;
   bucket_t *bucket = &params->buckets[seg->bucket_id];
 

--- a/libCacheSim/cache/eviction/GLCache/eviction.c
+++ b/libCacheSim/cache/eviction/GLCache/eviction.c
@@ -141,7 +141,7 @@ void GLCache_merge_segs(cache_t *cache, bucket_t *bucket, segment_t **segs) {
 // called when there is no segment can be merged due to fragmentation
 // different from clean_one_seg because this function also updates cache state
 int evict_one_seg(cache_t *cache, segment_t *seg) {
-  VVERBOSE("req %lu, evict one seg id %d occupied size %lu/%lu\n", cache->n_req,
+  VERBOSE("req %lu, evict one seg id %d occupied size %lu/%lu\n", cache->n_req,
            seg->seg_id, cache->occupied_byte, cache->cache_size);
   GLCache_params_t *params = cache->eviction_params;
   bucket_t *bucket = &params->buckets[seg->bucket_id];

--- a/libCacheSim/cache/eviction/LFU.c
+++ b/libCacheSim/cache/eviction/LFU.c
@@ -193,7 +193,7 @@ static cache_obj_t *LFU_find(cache_t *cache, const request_t *req,
       new_node->freq = cache_obj->lfu.freq;
       g_hash_table_insert(params->freq_map, new_key, new_node);
       VERBOSE("allocate new %ld %d %p %p\n", new_node->freq, new_node->n_obj,
-                new_node->first_obj, new_node->last_obj);
+              new_node->first_obj, new_node->last_obj);
     } else {
       // it could be new_node is empty
       DEBUG_ASSERT(new_node->freq == cache_obj->lfu.freq);

--- a/libCacheSim/cache/eviction/LFU.c
+++ b/libCacheSim/cache/eviction/LFU.c
@@ -192,7 +192,7 @@ static cache_obj_t *LFU_find(cache_t *cache, const request_t *req,
       memset(new_node, 0, sizeof(freq_node_t));
       new_node->freq = cache_obj->lfu.freq;
       g_hash_table_insert(params->freq_map, new_key, new_node);
-      VVVERBOSE("allocate new %ld %d %p %p\n", new_node->freq, new_node->n_obj,
+      VERBOSE("allocate new %ld %d %p %p\n", new_node->freq, new_node->n_obj,
                 new_node->first_obj, new_node->last_obj);
     } else {
       // it could be new_node is empty

--- a/libCacheSim/cache/eviction/LFUDA.c
+++ b/libCacheSim/cache/eviction/LFUDA.c
@@ -182,7 +182,7 @@ static cache_obj_t *LFUDA_find(cache_t *cache, const request_t *req,
       new_node->freq = cache_obj->lfu.freq;
       g_hash_table_insert(params->freq_map, new_key, new_node);
       VERBOSE("allocate new %ld %d %p %p\n", new_node->freq, new_node->n_obj,
-                new_node->first_obj, new_node->last_obj);
+              new_node->first_obj, new_node->last_obj);
     } else {
       // it could be new_node is empty
       DEBUG_ASSERT(new_node->freq == cache_obj->lfu.freq);

--- a/libCacheSim/cache/eviction/LFUDA.c
+++ b/libCacheSim/cache/eviction/LFUDA.c
@@ -181,7 +181,7 @@ static cache_obj_t *LFUDA_find(cache_t *cache, const request_t *req,
       memset(new_node, 0, sizeof(freq_node_t));
       new_node->freq = cache_obj->lfu.freq;
       g_hash_table_insert(params->freq_map, new_key, new_node);
-      VVVERBOSE("allocate new %ld %d %p %p\n", new_node->freq, new_node->n_obj,
+      VERBOSE("allocate new %ld %d %p %p\n", new_node->freq, new_node->n_obj,
                 new_node->first_obj, new_node->last_obj);
     } else {
       // it could be new_node is empty

--- a/libCacheSim/cache/eviction/LeCaR.c
+++ b/libCacheSim/cache/eviction/LeCaR.c
@@ -653,7 +653,7 @@ static inline void update_LFU_min_freq(LeCaR_params_t *params) {
     }
   }
   VERBOSE("update LFU min freq from %ld to %ld\n", old_min_freq,
-           params->min_freq);
+          params->min_freq);
   // if the object is the only object in the cache, we may have min_freq == 1
   DEBUG_ASSERT(params->min_freq > old_min_freq ||
                params->q_head == params->q_tail);
@@ -683,7 +683,7 @@ static inline void remove_obj_from_freq_node(LeCaR_params_t *params,
   DEBUG_ASSERT(freq_node->freq == cache_obj->LeCaR.freq);
   DEBUG_ASSERT(freq_node->n_obj > 0);
   VERBOSE("remove object from freq node %p (freq %ld, %u obj)\n", freq_node,
-           freq_node->freq, freq_node->n_obj);
+          freq_node->freq, freq_node->n_obj);
   freq_node->n_obj--;
 
   if (cache_obj == freq_node->first_obj) {

--- a/libCacheSim/cache/eviction/LeCaR.c
+++ b/libCacheSim/cache/eviction/LeCaR.c
@@ -288,7 +288,7 @@ static cache_obj_t *LeCaR_find(cache_t *cache, const request_t *req,
      * when remove_obj_from_freq_node */
     if (cache_obj->LeCaR.freq < params->min_freq) {
       params->min_freq = cache_obj->LeCaR.freq;
-      VVERBOSE("update min freq to %d\n", (int)params->min_freq);
+      VERBOSE("update min freq to %d\n", (int)params->min_freq);
     }
   }
 
@@ -312,7 +312,7 @@ static cache_obj_t *LeCaR_find(cache_t *cache, const request_t *req,
 cache_obj_t *LeCaR_insert(cache_t *cache, const request_t *req) {
   LeCaR_params_t *params = (LeCaR_params_t *)(cache->eviction_params);
 
-  VVERBOSE("insert object %lu into cache\n", (unsigned long)req->obj_id);
+  VERBOSE("insert object %lu into cache\n", (unsigned long)req->obj_id);
 
   // LRU and hash table insert
   cache_obj_t *cache_obj = cache_insert_base(cache, req);
@@ -652,7 +652,7 @@ static inline void update_LFU_min_freq(LeCaR_params_t *params) {
       break;
     }
   }
-  VVERBOSE("update LFU min freq from %ld to %ld\n", old_min_freq,
+  VERBOSE("update LFU min freq from %ld to %ld\n", old_min_freq,
            params->min_freq);
   // if the object is the only object in the cache, we may have min_freq == 1
   DEBUG_ASSERT(params->min_freq > old_min_freq ||
@@ -682,19 +682,19 @@ static inline void remove_obj_from_freq_node(LeCaR_params_t *params,
   DEBUG_ASSERT(freq_node != NULL);
   DEBUG_ASSERT(freq_node->freq == cache_obj->LeCaR.freq);
   DEBUG_ASSERT(freq_node->n_obj > 0);
-  VVERBOSE("remove object from freq node %p (freq %ld, %u obj)\n", freq_node,
+  VERBOSE("remove object from freq node %p (freq %ld, %u obj)\n", freq_node,
            freq_node->freq, freq_node->n_obj);
   freq_node->n_obj--;
 
   if (cache_obj == freq_node->first_obj) {
-    VVVERBOSE("remove object from freq node --- object is the first object\n");
+    VERBOSE("remove object from freq node --- object is the first object\n");
     freq_node->first_obj = cache_obj->LeCaR.lfu_next;
     if (cache_obj->LeCaR.lfu_next != NULL)
       ((cache_obj_t *)(cache_obj->LeCaR.lfu_next))->LeCaR.lfu_prev = NULL;
   }
 
   if (cache_obj == freq_node->last_obj) {
-    VVVERBOSE("remove object from freq node --- object is the last object\n");
+    VERBOSE("remove object from freq node --- object is the last object\n");
     freq_node->last_obj = cache_obj->LeCaR.lfu_prev;
     if (cache_obj->LeCaR.lfu_prev != NULL)
       ((cache_obj_t *)(cache_obj->LeCaR.lfu_prev))->LeCaR.lfu_next = NULL;
@@ -787,7 +787,7 @@ static void verify_ghost_lru_integrity(cache_t *cache, LeCaR_params_t *params) {
     cur = cur->queue.next;
   }
 
-  VVVERBOSE(
+  VERBOSE(
       "ghost entry head %p tail %p, "
       "ghost_entry_size from scan = %ld,"
       "lru_g_occupied_byte = %ld\n ",

--- a/libCacheSim/include/libCacheSim/const.h
+++ b/libCacheSim/include/libCacheSim/const.h
@@ -39,13 +39,11 @@ extern "C" {
 #define MAGENTA "\x1B[35m"
 #define CYAN "\x1B[36m"
 
-#define VVVERBOSE_LEVEL 3
-#define VVERBOSE_LEVEL 4
 #define VERBOSE_LEVEL 5
 #define DEBUG_LEVEL 6
 #define INFO_LEVEL 7
 #define WARN_LEVEL 8
-#define SEVERE_LEVEL 9
+#define ERROR_LEVEL 9
 
 // this is correct, to change to this, need to update test
 #define KiB 1024LL

--- a/libCacheSim/include/libCacheSim/logging.h
+++ b/libCacheSim/include/libCacheSim/logging.h
@@ -28,22 +28,6 @@ extern pthread_mutex_t log_mtx;
     pthread_mutex_unlock(&log_mtx);        \
   } while (0)
 
-#if LOGLEVEL <= VVVERBOSE_LEVEL
-#define VVVERBOSE(...) LOGGING(VVVERBOSE_LEVEL, __VA_ARGS__)
-#else
-#define VVVERBOSE(...) \
-  do {                 \
-  } while (0)
-#endif
-
-#if LOGLEVEL <= VVERBOSE_LEVEL
-#define VVERBOSE(...) LOGGING(VVERBOSE_LEVEL, __VA_ARGS__)
-#else
-#define VVERBOSE(...) \
-  do {                \
-  } while (0)
-#endif
-
 #if LOGLEVEL <= VERBOSE_LEVEL
 #define VERBOSE(...) LOGGING(VERBOSE_LEVEL, __VA_ARGS__)
 #else
@@ -76,11 +60,11 @@ extern pthread_mutex_t log_mtx;
   } while (0)
 #endif
 
-#if LOGLEVEL <= SEVERE_LEVEL
-#define ERROR(...)                      \
-  {                                     \
-    LOGGING(SEVERE_LEVEL, __VA_ARGS__); \
-    abort();                            \
+#if LOGLEVEL <= ERROR_LEVEL
+#define ERROR(...)                     \
+  {                                    \
+    LOGGING(ERROR_LEVEL, __VA_ARGS__); \
+    abort();                           \
   }
 #else
 #define ERROR(...)
@@ -119,12 +103,6 @@ extern pthread_mutex_t log_mtx;
 static inline void log_header(int level, const char *file, int line) {
   int n;
   switch (level) {
-    case VVVERBOSE_LEVEL:
-      n = fprintf(stderr, "%s[VVV]   ", CYAN);
-      break;
-    case VVERBOSE_LEVEL:
-      n = fprintf(stderr, "%s[VV]    ", CYAN);
-      break;
     case VERBOSE_LEVEL:
       n = fprintf(stderr, "%s[VERB]  ", MAGENTA);
       break;
@@ -137,7 +115,7 @@ static inline void log_header(int level, const char *file, int line) {
     case WARN_LEVEL:
       n = fprintf(stderr, "%s[WARN]  ", YELLOW);
       break;
-    case SEVERE_LEVEL:
+    case ERROR_LEVEL:
       n = fprintf(stderr, "%s[ERROR] ", RED);
       break;
     default:

--- a/libCacheSim/include/libCacheSim/macro.h
+++ b/libCacheSim/include/libCacheSim/macro.h
@@ -103,8 +103,6 @@ extern "C" {
 #define DEBUG_ASSERT(x)
 #endif
 
-// #pragma message "current LOGLEVEL: " XSTR(LOGLEVEL)
-
 #if LOGLEVEL > DEBUG_LEVEL
 #define THIS_IS_DEBUG_FUNC return
 #else
@@ -112,15 +110,9 @@ extern "C" {
 #endif
 
 #if LOGLEVEL > VERBOSE_LEVEL
-#define THIS_IS_DEBUG2_FUNC return
+#define THIS_IS_VERBOSE_FUNC return
 #else
-#define THIS_IS_DEBUG2_FUNC
-#endif
-
-#if LOGLEVEL > VVERBOSE_LEVEL
-#define THIS_IS_DEBUG3_FUNC return
-#else
-#define THIS_IS_DEBUG3_FUNC
+#define THIS_IS_VERBOSE_FUNC
 #endif
 
 #define PRINT_ONCE(...)          \
@@ -164,7 +156,7 @@ extern "C" {
 // int ffsl(long int i);
 // int ffsll(long long int i);
 
-#define find_max(array, n_elem, max_elem_ptr, max_elem_idx_ptr)               \
+#define FIND_MAX(array, n_elem, max_elem_ptr, max_elem_idx_ptr)               \
   do {                                                                        \
     *(max_elem_idx_ptr) = 0;                                                  \
     for (uint64_t i = 0; i < (uint64_t)(n_elem); i++)                         \
@@ -172,7 +164,7 @@ extern "C" {
     *(max_elem_ptr) = (array)[*(max_elem_idx_ptr)];                           \
   } while (0)
 
-#define find_min(array, n_elem, min_elem_ptr, min_elem_idx_ptr)               \
+#define FIND_MIN(array, n_elem, min_elem_ptr, min_elem_idx_ptr)               \
   do {                                                                        \
     *(min_elem_idx_ptr) = 0;                                                  \
     for (uint64_t i = 0; i < (uint64_t)(n_elem); i++)                         \

--- a/libCacheSim/traceReader/generalReader/txt.c
+++ b/libCacheSim/traceReader/generalReader/txt.c
@@ -10,7 +10,7 @@ int txt_read_one_req(reader_t *const reader, request_t *const req) {
   char **buf_ptr = (char **)&reader->line_buf;
   size_t *buf_size_ptr = &reader->line_buf_size;
   ssize_t read_size = getline(buf_ptr, buf_size_ptr, reader->file);
-  VVERBOSE("read \"%s\", first char %d, read size %zu, curr pos %zu\n",
+  VERBOSE("read \"%s\", first char %d, read size %zu, curr pos %zu\n",
            reader->line_buf, reader->line_buf[0], read_size,
            ftell(reader->file));
 

--- a/libCacheSim/traceReader/generalReader/txt.c
+++ b/libCacheSim/traceReader/generalReader/txt.c
@@ -11,8 +11,8 @@ int txt_read_one_req(reader_t *const reader, request_t *const req) {
   size_t *buf_size_ptr = &reader->line_buf_size;
   ssize_t read_size = getline(buf_ptr, buf_size_ptr, reader->file);
   VERBOSE("read \"%s\", first char %d, read size %zu, curr pos %zu\n",
-           reader->line_buf, reader->line_buf[0], read_size,
-           ftell(reader->file));
+          reader->line_buf, reader->line_buf[0], read_size,
+          ftell(reader->file));
 
   while (read_size == 1 && reader->line_buf[0] == '\n') {
     // empty line

--- a/libCacheSim/traceReader/reader.c
+++ b/libCacheSim/traceReader/reader.c
@@ -314,7 +314,7 @@ int read_one_req(reader_t *const reader, request_t *const req) {
     sampler_t *sampler = reader->sampler;
     reader->sampler = NULL;
     while (!sampler->sample(sampler, req)) {
-      VVERBOSE("skip one req: time %lu, obj_id %lu, size %lu at offset %zu\n",
+      VERBOSE("skip one req: time %lu, obj_id %lu, size %lu at offset %zu\n",
                req->clock_time, req->obj_id, req->obj_size, offset_before_read);
       if (reader->read_direction == READ_FORWARD) {
         status = read_one_req(reader, req);
@@ -333,7 +333,7 @@ int read_one_req(reader_t *const reader, request_t *const req) {
     req->obj_size = 1;
   }
 
-  VVERBOSE("read one req: time %lu, obj_id %lu, size %lu at offset %zu\n",
+  VERBOSE("read one req: time %lu, obj_id %lu, size %lu at offset %zu\n",
            req->clock_time, req->obj_id, req->obj_size, offset_before_read);
 
   return status;

--- a/libCacheSim/traceReader/reader.c
+++ b/libCacheSim/traceReader/reader.c
@@ -315,7 +315,7 @@ int read_one_req(reader_t *const reader, request_t *const req) {
     reader->sampler = NULL;
     while (!sampler->sample(sampler, req)) {
       VERBOSE("skip one req: time %lu, obj_id %lu, size %lu at offset %zu\n",
-               req->clock_time, req->obj_id, req->obj_size, offset_before_read);
+              req->clock_time, req->obj_id, req->obj_size, offset_before_read);
       if (reader->read_direction == READ_FORWARD) {
         status = read_one_req(reader, req);
       } else {
@@ -334,7 +334,7 @@ int read_one_req(reader_t *const reader, request_t *const req) {
   }
 
   VERBOSE("read one req: time %lu, obj_id %lu, size %lu at offset %zu\n",
-           req->clock_time, req->obj_id, req->obj_size, offset_before_read);
+          req->clock_time, req->obj_id, req->obj_size, offset_before_read);
 
   return status;
 }

--- a/libCacheSim/traceReader/sampling/SHARD.c
+++ b/libCacheSim/traceReader/sampling/SHARD.c
@@ -29,7 +29,7 @@ sampler_t *clone_SHARDS_sampler(const sampler_t *sampler) {
   sampler_t *cloned_sampler = my_malloc(sampler_t);
   memcpy(cloned_sampler, sampler, sizeof(sampler_t));
 
-  VERBOSE("clone spatial sampler\n");
+  VERBOSE("clone SHARDS sampler\n");
   return cloned_sampler;
 }
 

--- a/libCacheSim/traceReader/sampling/SHARD.c
+++ b/libCacheSim/traceReader/sampling/SHARD.c
@@ -29,7 +29,7 @@ sampler_t *clone_SHARDS_sampler(const sampler_t *sampler) {
   sampler_t *cloned_sampler = my_malloc(sampler_t);
   memcpy(cloned_sampler, sampler, sizeof(sampler_t));
 
-  VVERBOSE("clone spatial sampler\n");
+  VERBOSE("clone spatial sampler\n");
   return cloned_sampler;
 }
 
@@ -52,7 +52,7 @@ sampler_t *create_SHARDS_sampler(double sampling_ratio) {
 
   print_sampler(s);
 
-  VVERBOSE("create SHARDS sampler with ratio %lf\n", sampling_ratio);
+  VERBOSE("create SHARDS sampler with ratio %lf\n", sampling_ratio);
   return s;
 }
 

--- a/libCacheSim/traceReader/sampling/spatial.c
+++ b/libCacheSim/traceReader/sampling/spatial.c
@@ -30,7 +30,7 @@ sampler_t *clone_spatial_sampler(const sampler_t *sampler) {
   sampler_t *cloned_sampler = my_malloc(sampler_t);
   memcpy(cloned_sampler, sampler, sizeof(sampler_t));
 
-  VVERBOSE("clone spatial sampler\n");
+  VERBOSE("clone spatial sampler\n");
   return cloned_sampler;
 }
 
@@ -60,7 +60,7 @@ sampler_t *create_spatial_sampler(double sampling_ratio) {
 
   print_sampler(s);
 
-  VVERBOSE("create spatial sampler with ratio %lf\n", sampling_ratio);
+  VERBOSE("create spatial sampler with ratio %lf\n", sampling_ratio);
   return s;
 }
 
@@ -69,7 +69,7 @@ void set_spatial_sampler_salt(sampler_t *sampler, uint64_t salt) {
     ERROR("set spatial sampler salt error, sampler type %d\n", sampler->type);
   }
   sampler->sampling_salt = salt;
-  VVERBOSE("set spatial sampler salt to %lu\n", salt);
+  VERBOSE("set spatial sampler salt to %lu\n", salt);
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Removes `VVERBOSE` and `VVVERBOSE`, and renames `SEVERE` to `ERROR`. Let us use `VERBOSE` for per-request logging. 