### PR TITLE
[refactor]: cmake library installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ option(SUPPORT_TTL "whether support TTL" OFF)
 option(OPT_SUPPORT_ZSTD_TRACE "whether support zstd trace" ON)
 option(ENABLE_LRB "enable LRB" OFF)
 option(ENABLE_3L_CACHE "enable 3LCache" OFF)
+option(BUILD_SHARED_LIBS "build shared library" ON)
 set(LOG_LEVEL "default" CACHE STRING "change the logging level")
 set_property(CACHE LOG_LEVEL PROPERTY STRINGS ERROR WARN INFO DEBUG VERBOSE DEFAULT)
 
@@ -260,17 +261,6 @@ add_library(${PROJECT_NAME} STATIC
     $<TARGET_OBJECTS:mrcProfiler_lib>
 )
 
-add_library(${PROJECT_NAME}_shared SHARED
-    $<TARGET_OBJECTS:cache_lib_c>
-    $<TARGET_OBJECTS:cache_lib_cpp>
-    $<TARGET_OBJECTS:traceReader_lib>
-    $<TARGET_OBJECTS:profiler_lib>
-    $<TARGET_OBJECTS:dataStructure_lib>
-    $<TARGET_OBJECTS:utils_lib>
-    $<TARGET_OBJECTS:traceAnalyzer_lib>
-    $<TARGET_OBJECTS:mrcProfiler_lib>
-)
-
 # Set include directories for the unified library
 target_include_directories(${PROJECT_NAME} INTERFACE
     # Use separate BUILD_INTERFACE for each directory to avoid list expansion issues
@@ -280,20 +270,53 @@ target_include_directories(${PROJECT_NAME} INTERFACE
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-target_include_directories(${PROJECT_NAME}_shared INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libCacheSim/include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libCacheSim/utils/include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libCacheSim/>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-)
 
 # Link the static library to all required dependencies
 target_link_libraries(${PROJECT_NAME} PUBLIC ${dependency_libs})
-target_link_libraries(${PROJECT_NAME}_shared PUBLIC ${dependency_libs})
 
 # Set version and properties
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
-set_target_properties(${PROJECT_NAME}_shared PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
+
+# Install the static library
+install(TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}Targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+
+if(BUILD_SHARED_LIBS)
+    add_library(${PROJECT_NAME}_shared SHARED
+        $<TARGET_OBJECTS:cache_lib_c>
+        $<TARGET_OBJECTS:cache_lib_cpp>
+        $<TARGET_OBJECTS:traceReader_lib>
+        $<TARGET_OBJECTS:profiler_lib>
+        $<TARGET_OBJECTS:dataStructure_lib>
+        $<TARGET_OBJECTS:utils_lib>
+        $<TARGET_OBJECTS:traceAnalyzer_lib>
+        $<TARGET_OBJECTS:mrcProfiler_lib>
+    )
+
+    target_include_directories(${PROJECT_NAME}_shared INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libCacheSim/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libCacheSim/utils/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libCacheSim/>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    )
+
+    target_link_libraries(${PROJECT_NAME}_shared PUBLIC ${dependency_libs})
+
+    set_target_properties(${PROJECT_NAME}_shared PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
+
+    install(TARGETS ${PROJECT_NAME}_shared
+        EXPORT ${PROJECT_NAME}Targets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+endif()
+
 
 # Configuration files
 configure_file(${PROJECT_SOURCE_DIR}/${PROJECT_NAME}.pc.in ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc @ONLY)
@@ -306,21 +329,6 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Find${PROJECT_NAME}.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME} COMPONENT dev)
-
-# Install the unified library
-install(TARGETS ${PROJECT_NAME}
-    EXPORT ${PROJECT_NAME}Targets
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
-
-install(TARGETS ${PROJECT_NAME}_shared
-    EXPORT ${PROJECT_NAME}Targets
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
 
 # Install the export file
 install(EXPORT ${PROJECT_NAME}Targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(CMAKE_CXX_EXTENSIONS Off)
 
 # export compile commands, useful for IDEs
 set(EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Define build options
 # echo madvise | sudo tee /sys/kernel/mm/transparent_hugepage/enabled
@@ -112,28 +113,31 @@ include(GNUInstallDirs)
 set(dependency_libs "")
 
 find_package(Threads REQUIRED)
-set(dependency_libs ${dependency_libs} ${CMAKE_THREAD_LIBS_INIT})
+list(APPEND dependency_libs ${CMAKE_THREAD_LIBS_INIT})
+
+# Link standard math and dl libraries universally
+list(APPEND dependency_libs m dl)
 
 find_package(GLib REQUIRED)
-include_directories(${GLib_INCLUDE_DIRS})
-set(dependency_libs ${dependency_libs} ${GLib_LIBRARY})
+# Don't add GLib includes globally - add them to specific targets
+# include_directories(${GLib_INCLUDE_DIRS})
+list(APPEND dependency_libs ${GLib_LIBRARY})
 
 find_package(argp REQUIRED)
-include_directories(${ARGP_INCLUDE_DIRS})
-set(dependency_libs ${dependency_libs} ${ARGP_LIBRARY})
+# Don't add argp includes globally
+# include_directories(${ARGP_INCLUDE_DIRS})
+list(APPEND dependency_libs ${ARGP_LIBRARY})
 
 if(OPT_SUPPORT_ZSTD_TRACE)
     add_compile_definitions(SUPPORT_ZSTD_TRACE=1)
     find_package(ZSTD)
-
-    include_directories(${ZSTD_INCLUDE_DIR})
-
+    message(STATUS "ZSTD_INCLUDE_DIR ${ZSTD_INCLUDE_DIR}, ZSTD_LIBRARIES ${ZSTD_LIBRARIES}")
     if("${ZSTD_LIBRARIES}" STREQUAL "")
         message(FATAL_ERROR "zstd not found")
+    else()
+        include_directories(${ZSTD_INCLUDE_DIR})
+        list(APPEND dependency_libs ${ZSTD_LIBRARIES})
     endif()
-
-    set(dependency_libs ${dependency_libs} ${ZSTD_LIBRARIES})
-    message(STATUS "ZSTD_INCLUDE_DIR ${ZSTD_INCLUDE_DIR}, ZSTD_LIBRARIES ${ZSTD_LIBRARIES}")
 endif()
 
 # TCMalloc (libgoogle-perftools-dev google-perftools)
@@ -146,9 +150,10 @@ if(NOT ${CMAKE_BUILD_TYPE} MATCHES "Debug")
     if("${Tcmalloc_LIBRARY}" STREQUAL "")
         message(STATUS "!!! cannot find tcmalloc")
     else()
-        set(dependency_libs ${dependency_libs} ${Tcmalloc_LIBRARIES})
+        list(APPEND dependency_libs ${Tcmalloc_LIBRARIES})
         # tcmalloc flags will be set per target instead of globally
         set(tcmalloc_flags "-fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free")
+        list(APPEND LIBCACHESIM_C_FLAGS ${tcmalloc_flags})
     endif()
 endif()
 
@@ -157,7 +162,7 @@ find_package(Threads)
 if(ENABLE_GLCACHE)
     find_package(xgboost REQUIRED)
     include_directories(${XGBOOST_INCLUDE_DIR})
-    set(dependency_libs ${dependency_libs} xgboost::xgboost)
+    list(APPEND dependency_libs xgboost::xgboost)
     add_compile_definitions(ENABLE_GLCACHE=1)
     message(STATUS "XGBOOST_INCLUDE_DIR=${XGBOOST_INCLUDE_DIR}")
 endif()
@@ -168,13 +173,13 @@ foreach(FEATURE ENABLE_LRB ENABLE_3L_CACHE)
         if(NOT LIGHTGBM_PATH)
             message(FATAL_ERROR "LIGHTGBM_PATH not found")
         endif()
-        include_directories(${LIGHTGBM_PATH})
+        # include_directories(${LIGHTGBM_PATH})
 
         find_library(LIGHTGBM_LIB _lightgbm)
         if(NOT LIGHTGBM_LIB)
             message(FATAL_ERROR "LIGHTGBM_LIB not found")
         endif()
-        set(dependency_libs ${dependency_libs} ${LIGHTGBM_LIB})
+        list(APPEND dependency_libs ${LIGHTGBM_LIB})
         add_compile_definitions(${FEATURE}=1)
     endif()
 endforeach()
@@ -214,18 +219,11 @@ message(STATUS "============= Status of optional features ==============")
 message(STATUS "========================================================")
 
 # Define include directories for reuse in subdirectories
-set(libCacheSim_include_dir ${CMAKE_CURRENT_SOURCE_DIR}/libCacheSim/include ${CMAKE_CURRENT_SOURCE_DIR}/libCacheSim/utils/include ${CMAKE_CURRENT_SOURCE_DIR}/libCacheSim)
-set(libCacheSim_binary_include_dir ${CMAKE_CURRENT_BINARY_DIR}/libCacheSim/include)
-
-include_directories(${libCacheSim_include_dir})
-include_directories(${libCacheSim_binary_include_dir})
-# Restructured to avoid transitive dependency duplicates
-# profiler_lib already includes cache_lib_c, cache_lib_cpp, traceReader_lib (which includes utils_lib)
-# Only include top-level libraries to avoid duplicates
-set(all_modules cache_lib_c cache_lib_cpp traceReader_lib profiler_lib dataStructure_lib utils_lib traceAnalyzer_lib mrcProfiler_lib)
-# For linking: use minimal sets to avoid transitive dependency duplicates
-set(core_libs cache_lib_c cache_lib_cpp traceReader_lib dataStructure_lib utils_lib)
-set(high_level_libs profiler_lib traceAnalyzer_lib)
+set(libCacheSim_include_dir
+    ${CMAKE_CURRENT_SOURCE_DIR}/libCacheSim/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/libCacheSim/utils/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/libCacheSim
+)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/libCacheSim/cache)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/libCacheSim/dataStructure)
@@ -251,23 +249,50 @@ endif()
 
 # libCacheSim unified library compilation and installation
 # Create a single library that combines all modular libraries
-add_library(${PROJECT_NAME} INTERFACE)
+add_library(${PROJECT_NAME} STATIC
+    $<TARGET_OBJECTS:cache_lib_c>
+    $<TARGET_OBJECTS:cache_lib_cpp>
+    $<TARGET_OBJECTS:traceReader_lib>
+    $<TARGET_OBJECTS:profiler_lib>
+    $<TARGET_OBJECTS:dataStructure_lib>
+    $<TARGET_OBJECTS:utils_lib>
+    $<TARGET_OBJECTS:traceAnalyzer_lib>
+    $<TARGET_OBJECTS:mrcProfiler_lib>
+)
 
-# Link all modular libraries into the unified library
-target_link_libraries(${PROJECT_NAME} INTERFACE ${high_level_libs})
+add_library(${PROJECT_NAME}_shared SHARED
+    $<TARGET_OBJECTS:cache_lib_c>
+    $<TARGET_OBJECTS:cache_lib_cpp>
+    $<TARGET_OBJECTS:traceReader_lib>
+    $<TARGET_OBJECTS:profiler_lib>
+    $<TARGET_OBJECTS:dataStructure_lib>
+    $<TARGET_OBJECTS:utils_lib>
+    $<TARGET_OBJECTS:traceAnalyzer_lib>
+    $<TARGET_OBJECTS:mrcProfiler_lib>
+)
 
 # Set include directories for the unified library
 target_include_directories(${PROJECT_NAME} INTERFACE
-    $<BUILD_INTERFACE:${libCacheSim_include_dir}>
-    $<BUILD_INTERFACE:${libCacheSim_binary_include_dir}>
+    # Use separate BUILD_INTERFACE for each directory to avoid list expansion issues
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libCacheSim/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libCacheSim/utils/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libCacheSim/>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-# Link dependencies for the unified library
-target_link_libraries(${PROJECT_NAME} INTERFACE ${dependency_libs})
+target_include_directories(${PROJECT_NAME}_shared INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libCacheSim/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libCacheSim/utils/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libCacheSim/>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+# Link the static library to all required dependencies
+target_link_libraries(${PROJECT_NAME} PUBLIC ${dependency_libs})
 
 # Set version and properties
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
+set_target_properties(${PROJECT_NAME}_shared PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})
 
 # Configuration files
 configure_file(${PROJECT_SOURCE_DIR}/${PROJECT_NAME}.pc.in ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc @ONLY)
@@ -281,8 +306,15 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Find${PROJECT_NAME}.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME} COMPONENT dev)
 
-# Install all modular libraries and the unified interface library
-install(TARGETS ${PROJECT_NAME} ${all_modules}
+# Install the unified library
+install(TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}Targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(TARGETS ${PROJECT_NAME}_shared
     EXPORT ${PROJECT_NAME}Targets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -294,4 +326,3 @@ install(EXPORT ${PROJECT_NAME}Targets
     FILE ${PROJECT_NAME}Targets.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
 )
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,6 +289,7 @@ target_include_directories(${PROJECT_NAME}_shared INTERFACE
 
 # Link the static library to all required dependencies
 target_link_libraries(${PROJECT_NAME} PUBLIC ${dependency_libs})
+target_link_libraries(${PROJECT_NAME}_shared PUBLIC ${dependency_libs})
 
 # Set version and properties
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION})

--- a/libCacheSim/bin/MRC/CMakeLists.txt
+++ b/libCacheSim/bin/MRC/CMakeLists.txt
@@ -15,5 +15,6 @@ set(mrc_sources_c
 )
 
 add_executable(MRC ${mrc_sources_c})
-target_link_libraries(MRC ${core_libs} ${dependency_libs})
+target_include_directories(MRC PRIVATE ${libCacheSim_include_dir} ${GLib_INCLUDE_DIRS})
+target_link_libraries(MRC ${PROJECT_NAME})
 install(TARGETS MRC RUNTIME DESTINATION bin)

--- a/libCacheSim/bin/cachesim/CMakeLists.txt
+++ b/libCacheSim/bin/cachesim/CMakeLists.txt
@@ -9,8 +9,6 @@ set(cachesim_sources_c
     ../cli_reader_utils.c
 )
 add_executable(cachesim ${cachesim_sources_c})
-target_include_directories(cachesim PRIVATE ../)
-# Link just profiler_lib which now provides all needed libraries transitively
-target_link_libraries(cachesim profiler_lib)
-# target_link_options(cachesim PRIVATE "-Wl,--export-dynamic")  # Not supported on macOS
+target_include_directories(cachesim PRIVATE ${libCacheSim_include_dir} ${GLib_INCLUDE_DIRS} ../)
+target_link_libraries(cachesim ${PROJECT_NAME})
 install(TARGETS cachesim RUNTIME DESTINATION bin)

--- a/libCacheSim/bin/customized/SOSP23/CMakeLists.txt
+++ b/libCacheSim/bin/customized/SOSP23/CMakeLists.txt
@@ -9,8 +9,13 @@ set(traceOneHit_sources_cpp
     ../../cli_reader_utils.c
 )
 add_executable(traceOneHit ${traceOneHit_sources_cpp})
-target_include_directories(traceOneHit PRIVATE ../../)
-target_link_libraries(traceOneHit dataStructure_lib traceReader_lib ${Boost_LIBRARIES} ${dependency_libs})
+target_include_directories(traceOneHit PRIVATE
+    ../../
+    ${libCacheSim_include_dir}
+    ${GLib_INCLUDE_DIRS}
+)
+# target_link_libraries(traceOneHit dataStructure_lib traceReader_lib ${Boost_LIBRARIES} ${dependency_libs})
+target_link_libraries(traceOneHit dataStructure_lib traceReader_lib utils_lib ${Boost_LIBRARIES} ${dependency_libs})
 
 set(flash_sources_cpp
     flash/flash.cpp
@@ -18,5 +23,9 @@ set(flash_sources_cpp
     ../../cli_reader_utils.c
 )
 add_executable(flash ${flash_sources_cpp})
-target_include_directories(flash PRIVATE ../../)
-target_link_libraries(flash ${core_libs} ${dependency_libs})
+target_include_directories(flash PRIVATE
+    ../../
+    ${libCacheSim_include_dir}
+    ${GLib_INCLUDE_DIRS}
+)
+target_link_libraries(flash ${PROJECT_NAME} ${dependency_libs})

--- a/libCacheSim/bin/debug/CMakeLists.txt
+++ b/libCacheSim/bin/debug/CMakeLists.txt
@@ -3,11 +3,14 @@
 # ==============================================================================
 
 add_executable(debug main.cpp)
-target_link_libraries(debug ${core_libs} ${dependency_libs})
+target_include_directories(debug PRIVATE ${libCacheSim_include_dir} ${GLib_INCLUDE_DIRS})
+target_link_libraries(debug ${PROJECT_NAME})
 
 add_executable(debug_aligned aligned.c)
-target_link_libraries(debug_aligned ${core_libs} ${dependency_libs})
+target_include_directories(debug_aligned PRIVATE ${libCacheSim_include_dir} ${GLib_INCLUDE_DIRS})
+target_link_libraries(debug_aligned ${PROJECT_NAME})
 
 add_executable(debug_fileOp fileOp.cpp)
-target_link_libraries(debug_fileOp ${core_libs} ${dependency_libs})
+target_include_directories(debug_fileOp PRIVATE ${libCacheSim_include_dir} ${GLib_INCLUDE_DIRS})
+target_link_libraries(debug_fileOp ${PROJECT_NAME})
 

--- a/libCacheSim/bin/distUtil/CMakeLists.txt
+++ b/libCacheSim/bin/distUtil/CMakeLists.txt
@@ -8,5 +8,6 @@ set(distUtil_sources_c
     ../cli_reader_utils.c
 )
 add_executable(distUtil ${distUtil_sources_c})
-target_link_libraries(distUtil profiler_lib)
+target_include_directories(distUtil PRIVATE ${libCacheSim_include_dir} ${GLib_INCLUDE_DIRS})
+target_link_libraries(distUtil ${PROJECT_NAME})
 install(TARGETS distUtil RUNTIME DESTINATION bin)

--- a/libCacheSim/bin/mrcProfiler/CMakeLists.txt
+++ b/libCacheSim/bin/mrcProfiler/CMakeLists.txt
@@ -13,13 +13,9 @@ add_executable(mrcProfiler ${mrcProfiler_sources_cpp})
 target_compile_options(mrcProfiler PRIVATE
     $<$<COMPILE_LANGUAGE:C>:${LIBCACHESIM_C_FLAGS}>
     $<$<COMPILE_LANGUAGE:CXX>:${LIBCACHESIM_CXX_FLAGS}>
-    ${tcmalloc_flags}
 )
-
-target_link_libraries(mrcProfiler mrcProfiler_lib m dl)
-
-# target_link_options(mrcProfiler PRIVATE "-Wl,--export-dynamic")  # Not supported on macOS
-install(TARGETS mrcProfiler RUNTIME DESTINATION bin)
+target_include_directories(mrcProfiler PRIVATE ${libCacheSim_include_dir} ${GLib_INCLUDE_DIRS})
+target_link_libraries(mrcProfiler ${PROJECT_NAME})
 
 set_target_properties(mrcProfiler
         PROPERTIES
@@ -27,3 +23,5 @@ set_target_properties(mrcProfiler
         CXX_STANDARD_REQUIRED YES
         CXX_EXTENSIONS NO
 )
+
+install(TARGETS mrcProfiler RUNTIME DESTINATION bin)

--- a/libCacheSim/bin/traceAnalyzer/CMakeLists.txt
+++ b/libCacheSim/bin/traceAnalyzer/CMakeLists.txt
@@ -8,7 +8,8 @@ set(traceAnalyzer_sources_cpp
     ../cli_reader_utils.c
 )
 add_executable(traceAnalyzer ${traceAnalyzer_sources_cpp})
-target_link_libraries(traceAnalyzer traceAnalyzer_lib ${core_libs} ${dependency_libs})
+target_include_directories(traceAnalyzer PRIVATE ${libCacheSim_include_dir} ${GLib_INCLUDE_DIRS})
+target_link_libraries(traceAnalyzer ${PROJECT_NAME})
 install(TARGETS traceAnalyzer RUNTIME DESTINATION bin)
 
 set_target_properties(traceAnalyzer

--- a/libCacheSim/bin/traceUtils/CMakeLists.txt
+++ b/libCacheSim/bin/traceUtils/CMakeLists.txt
@@ -8,7 +8,7 @@ target_include_directories(cliReaderLib PRIVATE
     ${GLib_INCLUDE_DIRS}
 )
 target_compile_options(cliReaderLib PRIVATE ${LIBCACHESIM_C_FLAGS})
-target_link_libraries(cliReaderLib PRIVATE utils_lib)
+target_link_libraries(cliReaderLib PRIVATE ${PROJECT_NAME})
 
 set(tracePrint_sources_cpp
     tracePrintMain.cpp

--- a/libCacheSim/bin/traceUtils/CMakeLists.txt
+++ b/libCacheSim/bin/traceUtils/CMakeLists.txt
@@ -3,14 +3,20 @@
 # ==============================================================================
 
 add_library(cliReaderLib ../cli_reader_utils.c)
-
+target_include_directories(cliReaderLib PRIVATE
+    ${libCacheSim_include_dir}
+    ${GLib_INCLUDE_DIRS}
+)
+target_compile_options(cliReaderLib PRIVATE ${LIBCACHESIM_C_FLAGS})
+target_link_libraries(cliReaderLib PRIVATE utils_lib)
 
 set(tracePrint_sources_cpp
     tracePrintMain.cpp
     cli_parser.cpp
 )
 add_executable(tracePrint ${tracePrint_sources_cpp})
-target_link_libraries(tracePrint cliReaderLib ${core_libs} ${dependency_libs})
+target_include_directories(tracePrint PRIVATE ${libCacheSim_include_dir} ${GLib_INCLUDE_DIRS})
+target_link_libraries(tracePrint ${PROJECT_NAME} cliReaderLib)
 set_target_properties(tracePrint
         PROPERTIES
         CXX_STANDARD 17
@@ -28,7 +34,8 @@ set(traceConv_sources_cpp
     utils.cpp
 )
 add_executable(traceConv ${traceConv_sources_cpp})
-target_link_libraries(traceConv cliReaderLib ${core_libs} ${dependency_libs})
+target_include_directories(traceConv PRIVATE ${libCacheSim_include_dir} ${GLib_INCLUDE_DIRS})
+target_link_libraries(traceConv ${PROJECT_NAME} cliReaderLib)
 set_target_properties(traceConv
         PROPERTIES
         CXX_STANDARD 17
@@ -43,7 +50,8 @@ set(traceFilter_sources_cpp
     cli_parser.cpp
 )
 add_executable(traceFilter ${traceFilter_sources_cpp})
-target_link_libraries(traceFilter cliReaderLib ${core_libs} ${dependency_libs})
+target_include_directories(traceFilter PRIVATE ${libCacheSim_include_dir} ${GLib_INCLUDE_DIRS})
+target_link_libraries(traceFilter ${PROJECT_NAME} cliReaderLib)
 set_target_properties(traceFilter
         PROPERTIES
         CXX_STANDARD 17
@@ -52,4 +60,3 @@ set_target_properties(traceFilter
         )
 
 install(TARGETS traceFilter RUNTIME DESTINATION bin)
-

--- a/libCacheSim/cache/CMakeLists.txt
+++ b/libCacheSim/cache/CMakeLists.txt
@@ -152,30 +152,26 @@ set(cache_sources ${cache_sources} PARENT_SCOPE)
 message(STATUS "cache_sources_c = ${cache_sources_c}")
 message(STATUS "cache_sources_cpp = ${cache_sources_cpp}")
 
-add_library(cache_lib_c ${cache_sources_c})
-add_library(cache_lib_cpp ${cache_sources_cpp})
+add_library(cache_lib_c OBJECT ${cache_sources_c})
+add_library(cache_lib_cpp OBJECT ${cache_sources_cpp})
 
 # Set target-specific compiler flags
 target_compile_options(cache_lib_c PRIVATE
     ${LIBCACHESIM_C_FLAGS}
-    ${tcmalloc_flags}
 )
 
 target_compile_options(cache_lib_cpp PRIVATE
     ${LIBCACHESIM_CXX_FLAGS}
-    ${tcmalloc_flags}
 )
 
-target_include_directories(cache_lib_c PRIVATE 
+target_include_directories(cache_lib_c PRIVATE
     ${GLib_INCLUDE_DIRS}
     ${libCacheSim_include_dir}
-    ${libCacheSim_binary_include_dir}
 )
 
-target_include_directories(cache_lib_cpp PRIVATE 
+target_include_directories(cache_lib_cpp PRIVATE
     ${GLib_INCLUDE_DIRS}
     ${libCacheSim_include_dir}
-    ${libCacheSim_binary_include_dir}
 )
 
 target_link_libraries(cache_lib_c PRIVATE dataStructure_lib utils_lib ${dependency_libs})
@@ -187,4 +183,3 @@ set_target_properties(cache_lib_cpp PROPERTIES
     CXX_STANDARD_REQUIRED YES
     CXX_EXTENSIONS NO
 )
-

--- a/libCacheSim/dataStructure/CMakeLists.txt
+++ b/libCacheSim/dataStructure/CMakeLists.txt
@@ -14,19 +14,13 @@ set(dataStructure_sources_c
     hashtable/chainedHashTableV2.c
 )
 
-add_library(dataStructure_lib ${dataStructure_sources_c})
+add_library(dataStructure_lib OBJECT ${dataStructure_sources_c})
 
-# Set target-specific compiler flags
 target_compile_options(dataStructure_lib PRIVATE
     ${LIBCACHESIM_C_FLAGS}
-    ${tcmalloc_flags}
 )
 
-target_include_directories(dataStructure_lib PRIVATE 
+target_include_directories(dataStructure_lib PRIVATE
     ${GLib_INCLUDE_DIRS}
     ${libCacheSim_include_dir}
-    ${libCacheSim_binary_include_dir}
 )
-
-
-set(dataStructure_sources ${dataStructure_sources_c} PARENT_SCOPE)

--- a/libCacheSim/include/libCacheSim/request.h
+++ b/libCacheSim/include/libCacheSim/request.h
@@ -46,7 +46,7 @@ typedef struct request {
   struct {
     uint64_t key_size : 16;
     uint64_t val_size : 48;
-  };
+  } kv;
 
   int32_t ns;  // namespace
 

--- a/libCacheSim/mrcProfiler/CMakeLists.txt
+++ b/libCacheSim/mrcProfiler/CMakeLists.txt
@@ -7,7 +7,7 @@ set(mrcProfiler_sources_cpp
     mrcProfiler.cpp
 )
 
-add_library(mrcProfiler_lib ${mrcProfiler_sources_cpp})
+add_library(mrcProfiler_lib OBJECT ${mrcProfiler_sources_cpp})
 
 # Set C++ standard
 set_target_properties(mrcProfiler_lib PROPERTIES
@@ -19,16 +19,11 @@ set_target_properties(mrcProfiler_lib PROPERTIES
 # Set target-specific compiler flags
 target_compile_options(mrcProfiler_lib PRIVATE
     ${LIBCACHESIM_CXX_FLAGS}
-    ${tcmalloc_flags}
 )
 
-target_include_directories(mrcProfiler_lib PRIVATE 
+target_include_directories(mrcProfiler_lib PRIVATE
     ${GLib_INCLUDE_DIRS}
     ${libCacheSim_include_dir}
-    ${libCacheSim_binary_include_dir}
 )
 
-# Link dependencies - profiler_lib already brings in cache_lib_c, cache_lib_cpp, traceReader_lib, utils_lib, dataStructure_lib and dependency_libs
 target_link_libraries(mrcProfiler_lib PUBLIC profiler_lib)
-
-set(mrcProfiler_sources ${mrcProfiler_sources_cpp} PARENT_SCOPE)

--- a/libCacheSim/profiler/CMakeLists.txt
+++ b/libCacheSim/profiler/CMakeLists.txt
@@ -8,18 +8,16 @@ set(profiler_sources_c
     dist.c
 )
 
-add_library(profiler_lib ${profiler_sources_c})
+add_library(profiler_lib OBJECT ${profiler_sources_c})
 
 # Set target-specific compiler flags
 target_compile_options(profiler_lib PRIVATE
     ${LIBCACHESIM_C_FLAGS}
-    ${tcmalloc_flags}
 )
 
-target_include_directories(profiler_lib PRIVATE 
+target_include_directories(profiler_lib PRIVATE
     ${GLib_INCLUDE_DIRS}
     ${libCacheSim_include_dir}
-    ${libCacheSim_binary_include_dir}
 )
 
 # Use PUBLIC linking so dependencies are available to targets that link to profiler_lib

--- a/libCacheSim/traceAnalyzer/CMakeLists.txt
+++ b/libCacheSim/traceAnalyzer/CMakeLists.txt
@@ -24,15 +24,18 @@ set(traceAnalyzer_sources_cpp
     experimental/sizeChange.cpp
 )
 
-add_library(traceAnalyzer_lib ${traceAnalyzer_sources_cpp})
+add_library(traceAnalyzer_lib OBJECT ${traceAnalyzer_sources_cpp})
 target_include_directories(traceAnalyzer_lib PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
+    ${libCacheSim_include_dir}
+    ${GLib_INCLUDE_DIRS}
 )
-target_link_libraries(traceAnalyzer_lib PUBLIC ${dependency_libs})
+target_compile_options(traceAnalyzer_lib PRIVATE
+    ${LIBCACHESIM_CXX_FLAGS}
+)
+target_link_libraries(traceAnalyzer_lib PRIVATE ${dependency_libs})
 set_target_properties(traceAnalyzer_lib PROPERTIES
     CXX_STANDARD 17
     CXX_STANDARD_REQUIRED YES
     CXX_EXTENSIONS NO
 )
-
-set(traceAnalyzer_sources ${traceAnalyzer_sources_cpp} PARENT_SCOPE)

--- a/libCacheSim/traceAnalyzer/reuse.h
+++ b/libCacheSim/traceAnalyzer/reuse.h
@@ -17,11 +17,9 @@ class ReuseDistribution {
  public:
   explicit ReuseDistribution(std::string output_path,
                              int time_window_param = 300,
-                             int rtime_granularity_param = 5,
-                             int vtime_granularity_param = 1000)
+                             int rtime_granularity_param = 5)
       : time_window_(time_window_param),
-        rtime_granularity_(rtime_granularity_param),
-        vtime_granularity_(vtime_granularity_param) {
+        rtime_granularity_(rtime_granularity_param) {
     turn_on_stream_dump(output_path);
   };
 
@@ -48,7 +46,6 @@ class ReuseDistribution {
   const double log_log_base_ = log(log_base_);
   const int time_window_;
   const int rtime_granularity_;
-  const int vtime_granularity_;
   int64_t next_window_ts_ = -1;
 
   std::vector<uint32_t> window_reuse_rtime_req_cnt_;

--- a/libCacheSim/traceReader/CMakeLists.txt
+++ b/libCacheSim/traceReader/CMakeLists.txt
@@ -17,21 +17,15 @@ if (OPT_SUPPORT_ZSTD_TRACE)
     set(traceReader_sources_c ${traceReader_sources_c} generalReader/zstdReader.c)
 endif (OPT_SUPPORT_ZSTD_TRACE)
 
-add_library(traceReader_lib ${traceReader_sources_c})
+add_library(traceReader_lib OBJECT ${traceReader_sources_c})
 # Set target-specific compiler flags
 target_compile_options(traceReader_lib PRIVATE
     ${LIBCACHESIM_C_FLAGS}
-    ${tcmalloc_flags}
 )
 
-target_include_directories(traceReader_lib PRIVATE 
+target_include_directories(traceReader_lib PRIVATE
     ${GLib_INCLUDE_DIRS}
     ${libCacheSim_include_dir}
-    ${libCacheSim_binary_include_dir}
 )
 
 target_link_libraries(traceReader_lib PRIVATE utils_lib ${ZSTD_LIBRARIES})
-
-set(traceReader_sources ${traceReader_sources_c} PARENT_SCOPE)
-
-

--- a/libCacheSim/traceReader/customizedReader/oracle/oracleTwrBin.h
+++ b/libCacheSim/traceReader/customizedReader/oracle/oracleTwrBin.h
@@ -61,7 +61,7 @@ static inline int oracleSimTwrBin_read_one_req(reader_t *reader,
     req->next_access_vtime = MAX_REUSE_DISTANCE;
   }
 
-  if (req->val_size == 0 && reader->ignore_size_zero_req &&
+  if (req->kv.val_size == 0 && reader->ignore_size_zero_req &&
       (req->op == OP_GET || req->op == OP_GETS) &&
       reader->read_direction == READ_FORWARD)
     return oracleSimTwrBin_read_one_req(reader, req);
@@ -91,9 +91,9 @@ static inline int oracleSysTwrBin_read_one_req(reader_t *reader,
 
   req->clock_time = *(uint32_t *)record;
   req->obj_id = *(uint64_t *)(record + 4);
-  req->key_size = *(uint16_t *)(record + 12);
-  req->val_size = *(uint32_t *)(record + 14);
-  req->obj_size = req->key_size + req->val_size;
+  req->kv.key_size = *(uint16_t *)(record + 12);
+  req->kv.val_size = *(uint32_t *)(record + 14);
+  req->obj_size = req->kv.key_size + req->kv.val_size;
   req->op = (req_op_e)(*(uint16_t *)(record + 18));
   req->ns = *(uint16_t *)(record + 20);
   req->ttl = *(int32_t *)(record + 22);
@@ -102,10 +102,10 @@ static inline int oracleSysTwrBin_read_one_req(reader_t *reader,
     req->next_access_vtime = MAX_REUSE_DISTANCE;
   }
 
-  if (req->val_size == 0 && reader->ignore_size_zero_req &&
+  if (req->kv.val_size == 0 && reader->ignore_size_zero_req &&
       (req->op == OP_GET || req->op == OP_GETS) &&
       reader->read_direction == READ_FORWARD)
-    return oracleSimTwrBin_read_one_req(reader, req);
+    return oracleSysTwrBin_read_one_req(reader, req);
 
   return 0;
 }

--- a/libCacheSim/traceReader/customizedReader/oracle/oracleTwrNSBin.h
+++ b/libCacheSim/traceReader/customizedReader/oracle/oracleTwrNSBin.h
@@ -59,7 +59,7 @@ static int oracleSimTwrNSBin_read_one_req(reader_t *reader, request_t *req) {
     req->next_access_vtime = MAX_REUSE_DISTANCE;
   }
 
-  if (req->val_size == 0 && reader->ignore_size_zero_req &&
+  if (req->kv.val_size == 0 && reader->ignore_size_zero_req &&
       (req->op == OP_GET || req->op == OP_GETS) &&
       reader->read_direction == READ_FORWARD)
     return oracleSimTwrNSBin_read_one_req(reader, req);
@@ -85,9 +85,9 @@ static int oracleSysTwrNSBin_read_one_req(reader_t *reader, request_t *req) {
 
   req->clock_time = *(uint32_t *)record;
   req->obj_id = *(uint64_t *)(record + 4);
-  req->key_size = *(uint16_t *)(record + 12);
-  req->val_size = *(uint32_t *)(record + 14);
-  req->obj_size = req->key_size + req->val_size;
+  req->kv.key_size = *(uint16_t *)(record + 12);
+  req->kv.val_size = *(uint32_t *)(record + 14);
+  req->obj_size = req->kv.key_size + req->kv.val_size;
   req->op = *(uint16_t *)(record + 18);
   req->ns = *(uint16_t *)(record + 20);
   req->ttl = *(int32_t *)(record + 22);
@@ -97,7 +97,7 @@ static int oracleSysTwrNSBin_read_one_req(reader_t *reader, request_t *req) {
     req->next_access_vtime = MAX_REUSE_DISTANCE;
   }
 
-  if (req->val_size == 0 && reader->ignore_size_zero_req &&
+  if (req->kv.val_size == 0 && reader->ignore_size_zero_req &&
       (req->op == OP_GET || req->op == OP_GETS) &&
       reader->read_direction == READ_FORWARD) {
     ERROR("find size 0 request\n");

--- a/libCacheSim/traceReader/customizedReader/twrBin.h
+++ b/libCacheSim/traceReader/customizedReader/twrBin.h
@@ -49,13 +49,13 @@ static int twr_read_one_req(reader_t *reader, request_t *req) {
   uint32_t op = ((op_ttl >> 24) & (0x00000100 - 1));
   uint32_t ttl = op_ttl & (0x01000000 - 1);
 
-  req->key_size = key_size;
-  req->val_size = val_size;
+  req->kv.key_size = key_size;
+  req->kv.val_size = val_size;
   req->obj_size = key_size + val_size;
   req->op = (req_op_e)(op);
   req->ttl = (int32_t)ttl;
 
-  if (req->val_size == 0 && reader->ignore_size_zero_req &&
+  if (req->kv.val_size == 0 && reader->ignore_size_zero_req &&
       (req->op == OP_GET || req->op == OP_GETS) &&
       reader->read_direction == READ_FORWARD) {
     return twr_read_one_req(reader, req);

--- a/libCacheSim/traceReader/customizedReader/twrNSBin.h
+++ b/libCacheSim/traceReader/customizedReader/twrNSBin.h
@@ -50,13 +50,13 @@ static inline int twrNS_read_one_req(reader_t *reader, request_t *req) {
   uint32_t op = ((op_ttl >> 24) & (0x00000100 - 1));
   uint32_t ttl = op_ttl & (0x01000000 - 1);
 
-  req->key_size = key_size;
-  req->val_size = val_size;
+  req->kv.key_size = key_size;
+  req->kv.val_size = val_size;
   req->obj_size = key_size + val_size;
   req->op = (req_op_e)(op);
   req->ttl = (int32_t)ttl;
 
-  if (req->val_size == 0 && reader->ignore_size_zero_req &&
+  if (req->kv.val_size == 0 && reader->ignore_size_zero_req &&
       (req->op == OP_GET || req->op == OP_GETS) &&
       reader->read_direction == READ_FORWARD)
     return twrNS_read_one_req(reader, req);

--- a/libCacheSim/utils/CMakeLists.txt
+++ b/libCacheSim/utils/CMakeLists.txt
@@ -9,18 +9,14 @@ set(utils_sources_c
     mysys.c
 )
 
-add_library(utils_lib ${utils_sources_c})
+add_library(utils_lib OBJECT ${utils_sources_c})
 
 # Set target-specific compiler flags
 target_compile_options(utils_lib PRIVATE
     ${LIBCACHESIM_C_FLAGS}
-    ${tcmalloc_flags}
 )
 
-target_include_directories(utils_lib PRIVATE 
+target_include_directories(utils_lib PRIVATE
     ${GLib_INCLUDE_DIRS}
     ${libCacheSim_include_dir}
-    ${libCacheSim_binary_include_dir}
 )
-
-set(utils_sources ${utils_sources_c} PARENT_SCOPE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,7 +8,6 @@ function(add_test_executable target_name source_file)
         # C++ source file
         target_compile_options(${target_name} PRIVATE 
             ${LIBCACHESIM_CXX_FLAGS}
-            ${tcmalloc_flags}
         )
         set_target_properties(${target_name} PROPERTIES
             CXX_STANDARD 17
@@ -19,11 +18,17 @@ function(add_test_executable target_name source_file)
         # C source file
         target_compile_options(${target_name} PRIVATE 
             ${LIBCACHESIM_C_FLAGS}
-            ${tcmalloc_flags}
         )
     endif()
     
-    target_link_libraries(${target_name} profiler_lib)
+    target_link_libraries(${target_name} ${PROJECT_NAME})
+
+    # Add include directories for test compilation
+    target_include_directories(${target_name} PRIVATE
+        ${CMAKE_SOURCE_DIR}/libCacheSim  # Add source dir to find utils/include/mymath.h
+        ${libCacheSim_include_dir}
+        ${GLib_INCLUDE_DIRS}
+    )
 endfunction()
 
 # Create C test executables


### PR DESCRIPTION
I am in the process of re-enabling the plugin system and noticed that the current library installation does not work. So this PR tries to fix the library installation. 
Previously, we compiled each folder as a static library and installed all of them; however, we do not have a combined library. In this PR, each subfolder is compiled into an object, and we will install one library for libCacheSim. Currently we install both static and shared library. 
