### PR TITLE
add plugin_v2

### DIFF
--- a/example/plugin_v2/CMakeLists.txt
+++ b/example/plugin_v2/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.12)
 
 # Set the project name
-project(plugin_lru_hooks)
+project(plugin_lru_example)
+
 
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 17)
@@ -55,14 +56,6 @@ target_link_libraries(plugin_lru_hooks
     ${LIBCACHESIM_LIBRARY}
 )
 
-# Set library properties
-# set_target_properties(plugin_lru_hooks PROPERTIES
-#     VERSION 1.0.0
-#     SOVERSION 1
-#     OUTPUT_NAME "plugin_lru_hooks"
-# )
-
-# Optional: Add test executable if test file exists
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test_hooks_plugin.c")
     add_executable(test_hooks_plugin test_hooks_plugin.c)
     target_include_directories(test_hooks_plugin PRIVATE

--- a/example/plugin_v2/CMakeLists.txt
+++ b/example/plugin_v2/CMakeLists.txt
@@ -1,0 +1,78 @@
+cmake_minimum_required(VERSION 3.12)
+
+# Set the project name
+project(plugin_lru_hooks)
+
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED On)
+set(CMAKE_CXX_EXTENSIONS Off)
+
+# Enable position independent code for shared libraries
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# Find required dependencies
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GLIB REQUIRED glib-2.0)
+message(STATUS "GLIB library: ${GLIB_LIBRARIES}")
+message(STATUS "GLIB include: ${GLIB_INCLUDE_DIRS}")
+
+# Find libCacheSim
+find_library(LIBCACHESIM_LIBRARY
+    NAMES CacheSim libCacheSim
+    PATHS /usr/local/lib /usr/lib
+    DOC "libCacheSim unified library"
+)
+
+find_path(LIBCACHESIM_INCLUDE_DIR
+    NAMES libCacheSim.h
+    PATHS /usr/local/include /usr/include
+    DOC "libCacheSim include directory"
+)
+
+message(STATUS "libCacheSim library: ${LIBCACHESIM_LIBRARY}")
+message(STATUS "libCacheSim include: ${LIBCACHESIM_INCLUDE_DIR}")
+
+if(NOT LIBCACHESIM_LIBRARY OR NOT LIBCACHESIM_INCLUDE_DIR)
+    message(FATAL_ERROR "libCacheSim not found! Please install libCacheSim first.")
+endif()
+
+# Add the shared library target
+add_library(plugin_lru_hooks SHARED plugin_lru.cpp)
+
+# Set compiler flags
+target_compile_options(plugin_lru_hooks PRIVATE
+    -Wall -Wextra 
+    -Wno-unused-variable -Wno-unused-function -Wno-unused-parameter
+)
+target_include_directories(plugin_lru_hooks PRIVATE
+    ${GLIB_INCLUDE_DIRS}
+    ${LIBCACHESIM_INCLUDE_DIR}
+)
+# Link libraries
+target_link_libraries(plugin_lru_hooks
+    ${GLIB_LIBRARIES}
+    ${LIBCACHESIM_LIBRARY}
+)
+
+# Set library properties
+# set_target_properties(plugin_lru_hooks PROPERTIES
+#     VERSION 1.0.0
+#     SOVERSION 1
+#     OUTPUT_NAME "plugin_lru_hooks"
+# )
+
+# Optional: Add test executable if test file exists
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test_hooks_plugin.c")
+    add_executable(test_hooks_plugin test_hooks_plugin.c)
+    target_include_directories(test_hooks_plugin PRIVATE
+        ${LIBCACHESIM_INCLUDE_DIR}
+        ${GLIB_INCLUDE_DIRS}
+    )
+    target_link_libraries(test_hooks_plugin
+        ${GLIB_LIBRARIES}
+        ${LIBCACHESIM_LIBRARY}
+        dl
+        m
+    )
+endif()

--- a/example/plugin_v2/CMakeLists.txt
+++ b/example/plugin_v2/CMakeLists.txt
@@ -6,8 +6,8 @@ project(plugin_lru_example)
 
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED On)
-set(CMAKE_CXX_EXTENSIONS Off)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Enable position independent code for shared libraries
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/example/plugin_v2/README.md
+++ b/example/plugin_v2/README.md
@@ -1,13 +1,12 @@
-# Plugin LRU Hooks Example
+# Plugin V2 Example - LRU Cache with Hooks
 
-This example demonstrates how to create a plugin for libCacheSim using the hook-based system implemented in `plugin_cache.c`.
+This example demonstrates how to create a plugin for libCacheSim using the v2 hook-based plugin system. The plugin implements a standalone LRU (Least Recently Used) cache algorithm that integrates with libCacheSim's plugin_cache.c framework.
 
 ## Files
 
-- `plugin_lru_hooks.cpp` - The main LRU cache plugin implementation with hooks
-- `plugin_func.cpp` - Additional plugin functions
-- `test_hooks_plugin.c` - Test program for the plugin
-- `CMakeLists.txt` - Build configuration for creating a shared library
+- `plugin_lru.cpp` - The main LRU cache plugin implementation using hooks
+- `test_hooks_plugin.c` - Comprehensive test program for the plugin
+- `CMakeLists.txt` - Build configuration for creating the shared library
 
 ## Building
 
@@ -21,29 +20,68 @@ make
 ```
 
 This will create:
-- `libplugin_lru_hooks.so` - The shared library containing the plugin
-- `test_hooks_plugin` - A test executable (if test file exists)
+- `libplugin_lru_hooks.so` - Shared library
+- `test_hooks_plugin` - Test executable for validation
 
-## Plugin Interface
+## Plugin Architecture
 
-The plugin implements the following hook functions expected by libCacheSim's plugin system:
+The plugin implements a standalone LRU cache using C++ with a C interface for compatibility with libCacheSim. It uses:
 
-- `cache_init_hook()` - Initialize the cache data structure
-- `cache_hit_hook()` - Handle cache hits (move to head of LRU list)
+- **StandaloneLRU Class**: C++ implementation with doubly-linked list and hash map
+- **Hook Functions**: C interface functions that plugin_cache.c calls
+
+### Hook Functions
+
+The plugin implements these required hook functions:
+
+- `cache_init_hook()` - Initialize the LRU cache data structure
+- `cache_hit_hook()` - Handle cache hits (move object to head of LRU list)
 - `cache_miss_hook()` - Handle cache misses (insert new object)
-- `cache_eviction_hook()` - Evict least recently used object
+- `cache_eviction_hook()` - Evict least recently used object and return its ID
 - `cache_remove_hook()` - Remove specific object from cache
 
 ## Usage
 
+### With cachesim Binary
 
+```bash
+# Run cachesim with the plugin
+./bin/cachesim ../data/cloudPhysicsIO.vscsi vscsi lru,pluginCache 0.01,0.1 \
+  -e "plugin_path=/path/to/libCacheSim/example/plugin_v2/build/libplugin_lru_hooks.so"
 ```
-./bin/cachesim ../data/cloudPhysicsIO.vscsi vscsi lru,pluginCache 0.01,0.1 -e "plugin=/proj/cache-PG0/jason/libCacheSim/example/pluginv2/_build/libplugin_lru_hooks.so.1.0.0"
+
+### Testing the Plugin
+
+Run the included test to verify plugin functionality:
+
+```bash
+cd build
+./test_hooks_plugin
 ```
+
+The test compares the plugin LRU implementation against libCacheSim's built-in LRU to ensure identical behavior.
 
 ## Dependencies
 
-- libCacheSim headers
-- GLib (for basic data types)
-- C++17 compiler
-- CMake 3.12 or higher 
+- **libCacheSim**: Headers and libraries from the main project
+- **CMake 3.12+**: Build system
+
+## Plugin Parameter Format
+
+When using the plugin with cachesim or other libCacheSim tools, use the format:
+```
+plugin_path=/full/path/to/libplugin_lru_hooks.so
+```
+
+## Implementation Notes
+
+- The plugin uses C++ internally but exports C functions for compatibility
+- Memory management is handled automatically by the StandaloneLRU destructor
+- The implementation maintains the same LRU semantics as libCacheSim's built-in LRU
+- Thread safety is not implemented - suitable for single-threaded use cases
+
+## Troubleshooting
+
+- Ensure the plugin path uses the `plugin_path=` prefix format
+- Verify all dependencies are available (check with `ldd libplugin_lru_hooks.so`)
+- Use absolute paths when specifying the plugin location

--- a/example/plugin_v2/README.md
+++ b/example/plugin_v2/README.md
@@ -1,0 +1,49 @@
+# Plugin LRU Hooks Example
+
+This example demonstrates how to create a plugin for libCacheSim using the hook-based system implemented in `plugin_cache.c`.
+
+## Files
+
+- `plugin_lru_hooks.cpp` - The main LRU cache plugin implementation with hooks
+- `plugin_func.cpp` - Additional plugin functions
+- `test_hooks_plugin.c` - Test program for the plugin
+- `CMakeLists.txt` - Build configuration for creating a shared library
+
+## Building
+
+To compile the plugin into a shared library:
+
+```bash
+mkdir build
+cd build
+cmake ..
+make
+```
+
+This will create:
+- `libplugin_lru_hooks.so` - The shared library containing the plugin
+- `test_hooks_plugin` - A test executable (if test file exists)
+
+## Plugin Interface
+
+The plugin implements the following hook functions expected by libCacheSim's plugin system:
+
+- `cache_init_hook()` - Initialize the cache data structure
+- `cache_hit_hook()` - Handle cache hits (move to head of LRU list)
+- `cache_miss_hook()` - Handle cache misses (insert new object)
+- `cache_eviction_hook()` - Evict least recently used object
+- `cache_remove_hook()` - Remove specific object from cache
+
+## Usage
+
+
+```
+./bin/cachesim ../data/cloudPhysicsIO.vscsi vscsi lru,pluginCache 0.01,0.1 -e "plugin=/proj/cache-PG0/jason/libCacheSim/example/pluginv2/_build/libplugin_lru_hooks.so.1.0.0"
+```
+
+## Dependencies
+
+- libCacheSim headers
+- GLib (for basic data types)
+- C++17 compiler
+- CMake 3.12 or higher 

--- a/example/plugin_v2/plugin_lru.cpp
+++ b/example/plugin_v2/plugin_lru.cpp
@@ -1,0 +1,137 @@
+//
+// LRU Cache Plugin with Hooks for libCacheSim plugin_cache.c
+// This implements the hook-based plugin system that plugin_cache.c expects
+//
+
+#include <glib.h>
+#include <libCacheSim.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <unordered_map>
+
+class StandaloneLRU {
+ public:
+  struct Node {
+    obj_id_t obj_id;
+    uint64_t obj_size;
+    Node *prev;
+    Node *next;
+
+    Node(obj_id_t k = 0, uint64_t obj_size = 0)
+        : obj_id(k), obj_size(obj_size), prev(nullptr), next(nullptr) {}
+  };
+
+  std::unordered_map<obj_id_t, Node *> cache_map;
+  Node *head;
+  Node *tail;
+
+  StandaloneLRU() {
+    head = new Node();
+    tail = new Node();
+    head->next = tail;
+    tail->prev = head;
+  }
+
+  ~StandaloneLRU() {
+    while (head) {
+      Node *temp = head;
+      head = head->next;
+      delete temp;
+    }
+  }
+
+  void add_to_head(Node *node) {
+    node->prev = head;
+    node->next = head->next;
+    head->next->prev = node;
+    head->next = node;
+  }
+
+  void remove_node(Node *node) {
+    node->prev->next = node->next;
+    node->next->prev = node->prev;
+  }
+
+  Node *remove_tail() {
+    Node *last_node = tail->prev;
+    remove_node(last_node);
+    return last_node;
+  }
+
+  void move_to_head(Node *node) {
+    remove_node(node);
+    add_to_head(node);
+  }
+
+  void cache_hit(obj_id_t obj_id) {
+    Node *node = cache_map[obj_id];
+    move_to_head(node);
+  }
+
+  void cache_miss(obj_id_t obj_id, uint64_t obj_size) {
+    Node *new_node = new Node(obj_id, obj_size);
+    cache_map[obj_id] = new_node;
+    add_to_head(new_node);
+  }
+
+  obj_id_t cache_eviction() {
+    Node *node = remove_tail();
+    obj_id_t evicted_id = node->obj_id;
+    cache_map.erase(evicted_id);
+    delete node;
+    return evicted_id;
+  }
+
+  void cache_remove(obj_id_t obj_id) {
+    auto it = cache_map.find(obj_id);
+    if (it == cache_map.end()) {
+      return;
+    }
+    Node *node = it->second;
+    remove_node(node);
+    cache_map.erase(it);
+    delete node;
+  }
+};
+
+// C interface for the plugin hooks
+extern "C" {
+
+// implement the cache init hook
+void *cache_init_hook(const common_cache_params_t ccache_params) {
+  // initialize the LRU cache
+  StandaloneLRU *lru_cache = new StandaloneLRU();
+  return lru_cache;
+}
+
+// implement the cache hit hook
+void cache_hit_hook(void *data, const request_t *req) {
+  // move object to the head of the list
+  StandaloneLRU *lru_cache = (StandaloneLRU *)data;
+  lru_cache->cache_hit(req->obj_id);
+}
+
+// implement the cache miss hook
+void cache_miss_hook(void *data, const request_t *req) {
+  // insert object into the cache
+  StandaloneLRU *lru_cache = (StandaloneLRU *)data;
+  lru_cache->cache_miss(req->obj_id, req->obj_size);
+}
+
+// implement the cache eviction hook
+obj_id_t cache_eviction_hook(void *data, const request_t *req) {
+  // evict the least recently used object
+  StandaloneLRU *lru_cache = (StandaloneLRU *)data;
+  return lru_cache->cache_eviction();
+}
+
+// implement the cache remove hook
+void cache_remove_hook(void *data, const obj_id_t obj_id) {
+  // remove object from the cache
+  StandaloneLRU *lru_cache = (StandaloneLRU *)data;
+  lru_cache->cache_remove(obj_id);
+}
+
+}  // extern "C"

--- a/example/plugin_v2/test_hooks_plugin.c
+++ b/example/plugin_v2/test_hooks_plugin.c
@@ -1,0 +1,57 @@
+#include <assert.h>
+#include <libCacheSim.h>
+#include <libgen.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "libCacheSim/cache.h"
+#include "libCacheSim/evictionAlgo.h"
+
+static const char *plugin_lib_name = "libplugin_lru_hooks.so";
+
+int main(int argc, char *argv[]) {
+  common_cache_params_t cache_params = {
+      .cache_size = 1000,  // Small cache for easy testing
+      .default_ttl = 0,
+      .hashpower = 16,
+      .consider_obj_metadata = false,
+  };
+
+  // create a plugin LRU cache
+  char *curr_bin_path = strdup(argv[0]);
+  char *curr_dir = dirname(curr_bin_path);
+  char *plugin_path = malloc(strlen(curr_dir) + strlen(plugin_lib_name) + 20);
+  sprintf(plugin_path, "plugin_path=%s/%s", curr_dir, plugin_lib_name);
+  printf("plugin_path: %s\n", plugin_path);
+  cache_t *plugin_cache = pluginCache_init(cache_params, plugin_path);
+  assert(plugin_cache != NULL);
+
+  request_t *req = new_request();
+  assert(req != NULL);
+
+  // create a LRU cache
+  cache_t *lru_cache = LRU_init(cache_params, NULL);
+  assert(lru_cache != NULL);
+
+  // generate a 1000 random requests and compare the result of the plugin LRU
+  // cache and the default LRU cache
+  for (int i = 0; i < 1000; i++) {
+    req->obj_id = rand() % 1000;
+    req->obj_size = rand() % 10;
+    req->clock_time = i;
+
+    bool hit1 = plugin_cache->get(plugin_cache, req);
+    bool hit2 = lru_cache->get(lru_cache, req);
+    assert(hit1 == hit2);
+  }
+
+  // free the request
+  free_request(req);
+  plugin_cache->cache_free(plugin_cache);
+  lru_cache->cache_free(lru_cache);
+  printf("Plugin LRU cache and LRU cache are the same\n\n");
+  return 0;
+}

--- a/libCacheSim/bin/cachesim/cache_init.h
+++ b/libCacheSim/bin/cachesim/cache_init.h
@@ -56,6 +56,8 @@ static inline cache_t *create_cache(const char *trace_path,
       {"lru", LRU_init},
       {"lru-prob", LRU_Prob_init},
       {"nop", nop_init},
+      // plugin cache that allows user to implement custom cache
+      {"pluginCache", pluginCache_init},
       {"qdlp", QDLP_init},
       {"random", Random_init},
       {"RandomLRU", RandomLRU_init},

--- a/libCacheSim/bin/cachesim/cli_parser.c
+++ b/libCacheSim/bin/cachesim/cli_parser.c
@@ -117,7 +117,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
     case OPTION_EVICTION_PARAMS:
       arguments->eviction_params = strdup(arg);
       replace_char(arguments->eviction_params, ';', ',');
-      replace_char(arguments->eviction_params, '_', '-');
+      // replace_char(arguments->eviction_params, '_', '-');
       break;
     case OPTION_ADMISSION_ALGO:
       arguments->admission_algo = arg;
@@ -128,12 +128,12 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
     case OPTION_ADMISSION_PARAMS:
       arguments->admission_params = strdup(arg);
       replace_char(arguments->admission_params, ';', ',');
-      replace_char(arguments->admission_params, '_', '-');
+      // replace_char(arguments->admission_params, '_', '-');
       break;
     case OPTION_PREFETCH_PARAMS:
       arguments->prefetch_params = strdup(arg);
       replace_char(arguments->prefetch_params, ';', ',');
-      replace_char(arguments->prefetch_params, '_', '-');
+      // replace_char(arguments->prefetch_params, '_', '-');
       break;
     case OPTION_OUTPUT_PATH:
       strncpy(arguments->ofilepath, arg, OFILEPATH_LEN - 1);

--- a/libCacheSim/cache/CMakeLists.txt
+++ b/libCacheSim/cache/CMakeLists.txt
@@ -45,6 +45,7 @@ set(eviction_sources_c
         eviction/LRUv0.c         # an inefficient version but easier to understand
         eviction/MRU.c
         eviction/nop.c
+        eviction/plugin_cache.c  # plugin cache that allows user to implement custom cache
         eviction/QDLP.c
         eviction/Random.c
         eviction/RandomLRU.c

--- a/libCacheSim/cache/eviction/plugin_cache.c
+++ b/libCacheSim/cache/eviction/plugin_cache.c
@@ -371,6 +371,12 @@ static void pluginCache_parse_params(cache_t *cache,
     char *key = strsep((char **)&params_str, "=");
     char *value = strsep((char **)&params_str, ",");
 
+    // Check if value is NULL
+    if (value == NULL) {
+      ERROR("Parameter '%s' is missing a value in cache '%s'\n", key,
+            cache->cache_name);
+      exit(1);
+    }
     // Skip whitespace
     while (params_str != NULL && *params_str == ' ') {
       params_str++;

--- a/libCacheSim/cache/eviction/plugin_cache.c
+++ b/libCacheSim/cache/eviction/plugin_cache.c
@@ -1,0 +1,396 @@
+/**
+ * @file plugin_cache.c
+ * @brief Plugin cache implementation for libCacheSim
+ *
+ * This file implements a plugin-based cache that allows users to provide custom
+ * cache replacement algorithms via shared libraries. The plugin cache provides
+ * hooks for cache hit, cache miss, eviction, and removal, which are loaded at
+ * runtime from the user-specified plugin.
+ *
+ * The plugin must implement the following hook functions:
+ *   - cache_init_hook: Initialize plugin data structures
+ *   - cache_hit_hook: Handle cache hit events
+ *   - cache_miss_hook: Handle cache miss events
+ *   - cache_eviction_hook: Determine which object to evict
+ *   - cache_remove_hook: Clean up when objects are removed
+ *
+ * The plugin cache delegates core cache operations to these hooks, enabling
+ * flexible and extensible cache policies.
+ *
+ * @author Juncheng Yang
+ * @date Created in 2025
+ * @copyright Copyright © 2025 Juncheng. All rights reserved.
+ */
+
+#include <dlfcn.h>
+
+#include "dataStructure/hashtable/hashtable.h"
+#include "libCacheSim/evictionAlgo.h"
+#include "libCacheSim/plugin.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ***********************************************************************
+// ****                                                               ****
+// ****                    Data Structures                           ****
+// ****                                                               ****
+// ***********************************************************************
+
+/**
+ * @brief Plugin cache parameters structure
+ *
+ * Contains all plugin-specific data including the plugin path, loaded function
+ * pointers, and internal plugin data.
+ */
+typedef struct pluginCache_params {
+  char *plugin_path;                  ///< Path to the plugin shared library
+  void *data;                         ///< Plugin's internal data structure
+  cache_init_hook_t cache_init_hook;  ///< Plugin initialization function
+  cache_hit_hook_t cache_hit_hook;    ///< Cache hit handler function
+  cache_miss_hook_t cache_miss_hook;  ///< Cache miss handler function
+  cache_eviction_hook_t cache_eviction_hook;  ///< Eviction decision function
+  cache_remove_hook_t cache_remove_hook;  ///< Object removal handler function
+} pluginCache_params_t;
+
+/** @brief Default plugin parameters if none specified */
+static const char *DEFAULT_CACHE_PARAMS =
+    "plugin_path=./libplugin_lru_hooks.so";
+
+// ***********************************************************************
+// ****                                                               ****
+// ****                    Function Declarations                     ****
+// ****                                                               ****
+// ***********************************************************************
+
+static void pluginCache_parse_params(cache_t *cache,
+                                     const char *cache_specific_params);
+static void pluginCache_free(cache_t *cache);
+static bool pluginCache_get(cache_t *cache, const request_t *req);
+static cache_obj_t *pluginCache_find(cache_t *cache, const request_t *req,
+                                     const bool update_cache);
+static cache_obj_t *pluginCache_insert(cache_t *cache, const request_t *req);
+static cache_obj_t *pluginCache_to_evict(cache_t *cache, const request_t *req);
+static void pluginCache_evict(cache_t *cache, const request_t *req);
+static bool pluginCache_remove(cache_t *cache, const obj_id_t obj_id);
+
+// ***********************************************************************
+// ****                                                               ****
+// ****                    Public API Functions                      ****
+// ****                                                               ****
+// ***********************************************************************
+
+/**
+ * @brief Initialize a plugin cache instance
+ *
+ * Creates and initializes a plugin-based cache by loading the specified plugin
+ * shared library and setting up the hook functions. The plugin must export the
+ * required hook functions for proper operation.
+ *
+ * @param ccache_params Common cache parameters (size, TTL, etc.)
+ * @param cache_specific_params Plugin-specific parameters string (format:
+ * "key=value,key=value") Must include "plugin_path" parameter
+ * @return Pointer to initialized cache instance, or NULL on failure
+ *
+ * @note The plugin shared library must be accessible and export all required
+ * hook functions
+ * @see pluginCache_parse_params() for parameter format details
+ */
+cache_t *pluginCache_init(const common_cache_params_t ccache_params,
+                          const char *cache_specific_params) {
+  // Initialize base cache structure
+  cache_t *cache =
+      cache_struct_init("pluginCache", ccache_params, cache_specific_params);
+
+  // Set function pointers for cache operations
+  cache->cache_init = pluginCache_init;
+  cache->cache_free = pluginCache_free;
+  cache->get = pluginCache_get;
+  cache->find = pluginCache_find;
+  cache->insert = pluginCache_insert;
+  cache->evict = pluginCache_evict;
+  cache->remove = pluginCache_remove;
+  cache->to_evict = pluginCache_to_evict;
+  cache->get_occupied_byte = cache_get_occupied_byte_default;
+  cache->get_n_obj = cache_get_n_obj_default;
+  cache->can_insert = cache_can_insert_default;
+  cache->obj_md_size = 0;
+
+  // Allocate and initialize plugin parameters
+  cache->eviction_params =
+      (pluginCache_params_t *)malloc(sizeof(pluginCache_params_t));
+  pluginCache_params_t *params =
+      (pluginCache_params_t *)(cache->eviction_params);
+  memset(params, 0, sizeof(pluginCache_params_t));
+
+  // Parse parameters (default first, then user-specified)
+  pluginCache_parse_params(cache, DEFAULT_CACHE_PARAMS);
+  if (cache_specific_params != NULL) {
+    pluginCache_parse_params(cache, cache_specific_params);
+  }
+
+  // Load the plugin shared library
+  void *handle = dlopen(params->plugin_path, RTLD_NOW);
+  if (handle == NULL) {
+    ERROR("Failed to load plugin %s: %s\n", params->plugin_path, dlerror());
+    exit(1);
+  }
+
+  // Load hook functions from the plugin using unions to avoid pedantic warnings
+  union {
+    void *obj;
+    cache_init_hook_t func;
+  } cache_init_u;
+  union {
+    void *obj;
+    cache_hit_hook_t func;
+  } cache_hit_u;
+  union {
+    void *obj;
+    cache_miss_hook_t func;
+  } cache_miss_u;
+  union {
+    void *obj;
+    cache_eviction_hook_t func;
+  } cache_eviction_u;
+  union {
+    void *obj;
+    cache_remove_hook_t func;
+  } cache_remove_u;
+
+  cache_init_u.obj = dlsym(handle, "cache_init_hook");
+  params->cache_init_hook = cache_init_u.func;
+
+  cache_hit_u.obj = dlsym(handle, "cache_hit_hook");
+  params->cache_hit_hook = cache_hit_u.func;
+
+  cache_miss_u.obj = dlsym(handle, "cache_miss_hook");
+  params->cache_miss_hook = cache_miss_u.func;
+
+  cache_eviction_u.obj = dlsym(handle, "cache_eviction_hook");
+  params->cache_eviction_hook = cache_eviction_u.func;
+
+  cache_remove_u.obj = dlsym(handle, "cache_remove_hook");
+  params->cache_remove_hook = cache_remove_u.func;
+
+  // Initialize the plugin with cache parameters
+  params->data = params->cache_init_hook(ccache_params);
+
+  // Set cache name to include plugin path for identification
+  snprintf(cache->cache_name, CACHE_NAME_ARRAY_LEN, "pluginCache-%s",
+           params->plugin_path);
+
+  return cache;
+}
+
+/**
+ * @brief Free resources used by the plugin cache
+ *
+ * Cleans up all resources allocated by the plugin cache, including
+ * plugin-specific parameters and base cache structures.
+ *
+ * @param cache Pointer to the cache instance to free
+ */
+static void pluginCache_free(cache_t *cache) {
+  free(cache->eviction_params);
+  cache_struct_free(cache);
+}
+
+/**
+ * @brief Main cache access function (user-facing API)
+ *
+ * Implements the standard cache access pattern:
+ * 1. Check if object exists in cache
+ * 2. If hit: call plugin hit hook and return true
+ * 3. If miss: evict objects if needed, insert new object, call plugin miss
+ * hook, return false
+ *
+ * @param cache Pointer to the cache instance
+ * @param req Cache request containing object ID, size, and timestamp
+ * @return true if cache hit, false if cache miss
+ */
+static bool pluginCache_get(cache_t *cache, const request_t *req) {
+  bool hit = cache_get_base(cache, req);
+  pluginCache_params_t *params = (pluginCache_params_t *)cache->eviction_params;
+
+  if (hit) {
+    params->cache_hit_hook(params->data, req);
+  } else {
+    params->cache_miss_hook(params->data, req);
+  }
+
+  return hit;
+}
+
+// ***********************************************************************
+// ****                                                               ****
+// ****                Developer-Facing Functions                    ****
+// ****                                                               ****
+// ***********************************************************************
+
+/**
+ * @brief Find an object in the cache
+ *
+ * Searches for an object in the cache and optionally updates cache metadata
+ * such as access time or promotion in the replacement policy.
+ *
+ * @param cache Pointer to the cache instance
+ * @param req Cache request containing the object to find
+ * @param update_cache Whether to update cache metadata on access
+ * @return Pointer to the cache object if found, NULL otherwise
+ */
+static cache_obj_t *pluginCache_find(cache_t *cache, const request_t *req,
+                                     const bool update_cache) {
+  return cache_find_base(cache, req, update_cache);
+}
+
+/**
+ * @brief Insert an object into the cache
+ *
+ * Inserts a new object into the cache, updating the hash table and cache
+ * metadata. This function assumes the cache has sufficient space; eviction
+ * should be handled separately before calling this function.
+ *
+ * @param cache Pointer to the cache instance
+ * @param req Cache request containing the object to insert
+ * @return Pointer to the inserted cache object
+ */
+static cache_obj_t *pluginCache_insert(cache_t *cache, const request_t *req) {
+  return cache_insert_base(cache, req);
+}
+
+/**
+ * @brief Find the object to be evicted (not supported)
+ *
+ * This function is not supported by the plugin cache because eviction logic
+ * is delegated to the plugin's eviction hook, which may have complex internal
+ * state that cannot be easily queried.
+ *
+ * @param cache Pointer to the cache instance
+ * @param req Current cache request (unused)
+ * @return Never returns (calls exit)
+ *
+ * @note This function always terminates the program with an error
+ */
+static cache_obj_t *pluginCache_to_evict(cache_t *cache, const request_t *req) {
+  ERROR("pluginCache does not support to_evict function\n");
+  exit(1);
+}
+
+/**
+ * @brief Evict an object from the cache
+ *
+ * Delegates eviction decision to the plugin's eviction hook, then removes
+ * the selected object from the cache. Updates all cache metadata including
+ * object count, occupied size, and hash table.
+ *
+ * @param cache Pointer to the cache instance
+ * @param req Current cache request (passed to plugin for context)
+ *
+ * @note The plugin's eviction hook must return a valid object ID that exists in
+ * the cache
+ */
+static void pluginCache_evict(cache_t *cache, const request_t *req) {
+  pluginCache_params_t *params = (pluginCache_params_t *)cache->eviction_params;
+
+  // Get eviction candidate from plugin
+  obj_id_t obj_id = params->cache_eviction_hook(params->data, req);
+
+  // Find the object in the cache
+  cache_obj_t *obj_to_evict = hashtable_find_obj_id(cache->hashtable, obj_id);
+  if (obj_to_evict == NULL) {
+    ERROR("pluginCache: object %" PRIu64 " to be evicted not found in cache\n",
+          obj_id);
+    exit(1);
+  }
+
+  // Perform the eviction
+  cache_evict_base(cache, obj_to_evict, true);
+}
+
+/**
+ * @brief Remove an object from the cache
+ *
+ * Removes a specific object from the cache, typically in response to an
+ * explicit user request rather than automatic eviction. Notifies the plugin of
+ * the removal and updates all cache metadata.
+ *
+ * @param cache Pointer to the cache instance
+ * @param obj_id ID of the object to remove
+ * @return true if the object was found and removed, false if not found
+ */
+static bool pluginCache_remove(cache_t *cache, const obj_id_t obj_id) {
+  pluginCache_params_t *params = (pluginCache_params_t *)cache->eviction_params;
+
+  // Notify plugin of the removal
+  params->cache_remove_hook(params->data, obj_id);
+
+  // Find the object in the cache
+  cache_obj_t *obj = hashtable_find_obj_id(cache->hashtable, obj_id);
+  if (obj == NULL) {
+    return false;
+  }
+
+  // Remove the object from the cache
+  cache_remove_obj_base(cache, obj, true);
+  return true;
+}
+
+// ***********************************************************************
+// ****                                                               ****
+// ****                    Parameter Parsing                         ****
+// ****                                                               ****
+// ***********************************************************************
+
+/**
+ * @brief Parse plugin cache parameters from string
+ *
+ * Parses a parameter string in the format "key1=value1,key2=value2,..."
+ * and updates the plugin cache configuration accordingly.
+ *
+ * Supported parameters:
+ * - plugin_path: Path to the plugin shared library
+ * - print: Print current parameters and exit (for debugging)
+ *
+ * @param cache Pointer to the cache instance
+ * @param cache_specific_params Parameter string to parse
+ *
+ * @note Invalid parameters will cause the program to exit with an error
+ */
+static void pluginCache_parse_params(cache_t *cache,
+                                     const char *cache_specific_params) {
+  pluginCache_params_t *params =
+      (pluginCache_params_t *)(cache->eviction_params);
+
+  char *params_str = strdup(cache_specific_params);
+  char *old_params_str = params_str;
+
+  while (params_str != NULL && params_str[0] != '\0') {
+    // Parse key=value pairs separated by commas
+    char *key = strsep((char **)&params_str, "=");
+    char *value = strsep((char **)&params_str, ",");
+
+    // Skip whitespace
+    while (params_str != NULL && *params_str == ' ') {
+      params_str++;
+    }
+
+    // Process recognized parameters
+    if (strcasecmp(key, "plugin") == 0 || strcasecmp(key, "plugin_path") == 0) {
+      params->plugin_path = strdup(value);
+    } else if (strcasecmp(key, "print") == 0) {
+      printf("current parameters: plugin_path=%s\n", params->plugin_path);
+      exit(0);
+    } else {
+      ERROR("%s does not have parameter %s\n", cache->cache_name, key);
+      exit(1);
+    }
+  }
+
+  free(old_params_str);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/libCacheSim/include/libCacheSim/evictionAlgo.h
+++ b/libCacheSim/include/libCacheSim/evictionAlgo.h
@@ -119,6 +119,10 @@ cache_t *MRU_init(const common_cache_params_t ccache_params,
 cache_t *nop_init(const common_cache_params_t ccache_params,
                   const char *cache_specific_params);
 
+// plugin cache that allows user to implement custom cache
+cache_t *pluginCache_init(const common_cache_params_t ccache_params,
+                          const char *cache_specific_params);
+
 cache_t *QDLP_init(const common_cache_params_t ccache_params,
                    const char *cache_specific_params);
 

--- a/libCacheSim/include/libCacheSim/logging.h
+++ b/libCacheSim/include/libCacheSim/logging.h
@@ -122,6 +122,7 @@ static inline void log_header(int level, const char *file, int line) {
       n = fprintf(stderr, "in logging should not be here\n");
       break;
   }
+  (void)n;  // explicitly mark as unused
 
   char buffer[30];
   struct timeval tv;

--- a/libCacheSim/include/libCacheSim/plugin.h
+++ b/libCacheSim/include/libCacheSim/plugin.h
@@ -1,6 +1,14 @@
-//
-// Created by Juncheng Yang on 11/17/19.
-//
+/**
+ * @file plugin.h
+ * @brief Plugin API for libCacheSim cache implementations
+ *
+ * This header defines two plugin APIs for implementing custom cache algorithms:
+ * - v1 API: Full cache implementation using libCacheSim data structures
+ * - v2 API: Hook-based implementation for easy integration with existing caches
+ *
+ * @author Juncheng Yang
+ * @date Created on 11/17/19
+ */
 
 #ifndef libCacheSim_PLUGIN_H
 #define libCacheSim_PLUGIN_H
@@ -12,50 +20,173 @@
 extern "C" {
 #endif
 
+// ***********************************************************************
+// ****                                                               ****
+// ****                   V1 Plugin API                              ****
+// ****                                                               ****
+// ***********************************************************************
+
 /**
- * create a cache handler, using the cache replacement algorithm is baked into
- * libCacheSim
- * @param cache_alg_name name of the cache replacement algorithm (case
+ * @defgroup v1_plugin_api V1 Plugin API
+ * @brief Full cache implementation API using libCacheSim data structures
+ *
+ * The v1 plugin API requires implementing a complete cache using libCacheSim
+ * data structures similar to the built-in LRU implementation. This provides
+ * the lowest overhead and full integration with libCacheSim.
+ * @{
+ */
+
+/**
+ * @brief Create a cache handler using a built-in cache replacement algorithm
+ *
+ * Creates a cache instance using one of the cache replacement algorithms
+ * that are compiled into libCacheSim.
+ *
+ * @param cache_alg_name Name of the cache replacement algorithm (case
  * sensitive)
- * @param cc_params general parameters that are used to initialize cache, such
- * as cache_size, obj_id_type, support_ttl
- * @param params a cache eviction algorithm specific params
- * @return cache handler
+ * @param cc_params General cache parameters (cache_size, obj_id_type,
+ * support_ttl, etc.)
+ * @param cache_specific_params Algorithm-specific parameters (can be NULL)
+ * @return Pointer to initialized cache handler, or NULL on failure
  */
 cache_t *create_cache(const char *const cache_alg_name,
                       common_cache_params_t cc_params,
                       void *cache_specific_params);
 
 /**
- * create a cache handler, using the cache replacement algorithm is baked into
- * libCacheSim
- * @param cache_alg_name name of the cache replacement algorithm (case
+ * @brief Internal cache creation function
+ *
+ * Similar to create_cache() but for internal use within libCacheSim.
+ *
+ * @param cache_alg_name Name of the cache replacement algorithm (case
  * sensitive)
- * @param cc_params general parameters that are used to initialize cache, such
- * as cache_size, obj_id_type, support_ttl
- * @param params a cache eviction algorithm specific params
- * @return cache handler
+ * @param cc_params General cache parameters
+ * @param cache_specific_params Algorithm-specific parameters (can be NULL)
+ * @return Pointer to initialized cache handler, or NULL on failure
  */
 cache_t *create_cache_internal(const char *const cache_alg_name,
                                common_cache_params_t cc_params,
                                void *cache_specific_params);
 
 /**
- * create a cache handler, using an external cache replacement algorithm, for
- * now we assume the external cache replacement algorithm is compiled into a
- * shared library and stored in the working directory and the name is <alg>.so
- * where alg is the name of the cache replacement algorithm passed to this
- * function
- * @param cache_alg_name name of the cache replacement algorithm (case
+ * @brief Create a cache handler using an external cache replacement algorithm
+ *
+ * Creates a cache instance using an external cache replacement algorithm
+ * compiled into a shared library. The library should be named <alg>.so
+ * where <alg> is the algorithm name passed to this function.
+ *
+ * @param cache_alg_name Name of the cache replacement algorithm (case
  * sensitive)
- * @param cc_params general parameters that are used to initialize cache, such
- * as cache_size, obj_id_type, support_ttl
- * @param params a cache eviction algorithm specific params
- * @return cache handler
+ * @param cc_params General cache parameters
+ * @param cache_specific_params Algorithm-specific parameters (can be NULL)
+ * @return Pointer to initialized cache handler, or NULL on failure
+ *
+ * @note The shared library must be in the working directory
  */
 cache_t *create_cache_external(const char *const cache_alg_name,
                                common_cache_params_t cc_params,
                                void *cache_specific_params);
+
+/** @} */  // end of v1_plugin_api group
+
+// ***********************************************************************
+// ****                                                               ****
+// ****                   V2 Plugin Cache API                        ****
+// ****                                                               ****
+// ***********************************************************************
+
+/**
+ * @defgroup v2_plugin_api V2 Plugin Cache API
+ * @brief Hook-based plugin API for easy cache integration
+ *
+ * The v2 plugin cache API allows implementing a cache plugin by providing
+ * five core hook functions. This design enables easy integration on top of
+ * existing cache implementations without requiring full reimplementation.
+ *
+ * Required hooks:
+ * - cache_init_hook: Initialize plugin data structures
+ * - cache_hit_hook: Handle cache hit events
+ * - cache_miss_hook: Handle cache miss events
+ * - cache_eviction_hook: Determine which object to evict
+ * - cache_remove_hook: Clean up when objects are removed
+ *
+ * @see example/plugin_v2/plugin_lru.c for a complete implementation example
+ * @{
+ */
+
+/**
+ * @brief Cache initialization hook function type
+ *
+ * This function is called during cache initialization to set up any
+ * plugin-specific data structures. The plugin should allocate and
+ * initialize any internal state needed for cache operations.
+ *
+ * @param ccache_params Cache configuration parameters
+ * @return Pointer to plugin's internal data structure, or NULL on failure
+ *
+ * @note The returned pointer will be passed to all other hook functions
+ */
+typedef void *(*cache_init_hook_t)(const common_cache_params_t ccache_params);
+
+/**
+ * @brief Cache hit hook function type
+ *
+ * Called when a requested object is found in the cache. The plugin should
+ * perform any necessary bookkeeping operations, such as updating access
+ * order for LRU-based algorithms.
+ *
+ * @param data Pointer to plugin's internal data (from cache_init_hook)
+ * @param req The cache request being processed
+ *
+ * @note This function should not modify the cache contents, only metadata
+ */
+typedef void (*cache_hit_hook_t)(void *data, const request_t *req);
+
+/**
+ * @brief Cache miss hook function type
+ *
+ * Called when a requested object is not found in the cache. The plugin
+ * should perform any necessary bookkeeping for the new object that will
+ * be inserted, such as adding it to tracking data structures.
+ *
+ * @param data Pointer to plugin's internal data (from cache_init_hook)
+ * @param req The cache request being processed
+ *
+ * @note The actual object insertion is handled by the cache framework
+ */
+typedef void (*cache_miss_hook_t)(void *data, const request_t *req);
+
+/**
+ * @brief Cache eviction hook function type
+ *
+ * Called when the cache is full and an object must be evicted to make space.
+ * The plugin should determine which object to evict based on its replacement
+ * policy and return the object ID.
+ *
+ * @param data Pointer to plugin's internal data (from cache_init_hook)
+ * @param req The cache request currently being processed
+ * @return Object ID of the object to be evicted
+ *
+ * @warning The returned object ID must correspond to a valid object in the
+ * cache
+ */
+typedef obj_id_t (*cache_eviction_hook_t)(void *data, const request_t *req);
+
+/**
+ * @brief Cache removal hook function type
+ *
+ * Called when an object is being removed from the cache (either due to
+ * eviction or explicit deletion). The plugin should clean up any internal
+ * state associated with the object.
+ *
+ * @param data Pointer to plugin's internal data (from cache_init_hook)
+ * @param obj_id Object ID of the object being removed
+ *
+ * @note This is called after the object has been removed from the cache
+ */
+typedef void (*cache_remove_hook_t)(void *data, const obj_id_t obj_id);
+
+/** @} */  // end of v2_plugin_api group
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This is the new plugin system for C/C++ users. 

The v2 plugin cache API allows implementing a cache plugin by providing four core hook functions. This design enables easy integration on top of an user's existing cache implementations without requiring a full libCacheSim-based implementation. 
