### PR TITLE
Fix: add cache free hook and default param free

### DIFF
--- a/example/plugin_v2/README.md
+++ b/example/plugin_v2/README.md
@@ -43,6 +43,7 @@ The plugin implements these required hook functions:
 - `cache_miss_hook()` - Handle cache misses (insert new object)
 - `cache_eviction_hook()` - Evict least recently used object and return its ID
 - `cache_remove_hook()` - Remove specific object from cache
+- `cache_free_hook()` - Clean up and free the LRU cache data structure
 
 ## Usage
 

--- a/example/plugin_v2/plugin_lru.cpp
+++ b/example/plugin_v2/plugin_lru.cpp
@@ -134,4 +134,11 @@ void cache_remove_hook(void *data, const obj_id_t obj_id) {
   lru_cache->cache_remove(obj_id);
 }
 
+// implement the cache free hook
+void cache_free_hook(void *data) {
+  // free the LRU cache (destructor handles all cleanup)
+  StandaloneLRU *lru_cache = (StandaloneLRU *)data;
+  delete lru_cache;
+}
+
 }  // extern "C"

--- a/libCacheSim/cache/eviction/plugin_cache.c
+++ b/libCacheSim/cache/eviction/plugin_cache.c
@@ -47,7 +47,7 @@ extern "C" {
  */
 typedef struct pluginCache_params {
   char *plugin_path;                  ///< Path to the plugin shared library
-  void *handle;                       ///< Handle to the loaded plugin library
+  void *plugin_handle;                ///< Handle to the loaded plugin library
   void *data;                         ///< Plugin's internal data structure
   cache_init_hook_t cache_init_hook;  ///< Plugin initialization function
   cache_hit_hook_t cache_hit_hook;    ///< Cache hit handler function
@@ -140,7 +140,7 @@ cache_t *pluginCache_init(const common_cache_params_t ccache_params,
     ERROR("Failed to load plugin %s: %s\n", params->plugin_path, dlerror());
     exit(1);
   }
-  params->handle = handle;
+  params->plugin_handle = handle;
 
   // Load hook functions from the plugin using unions to avoid pedantic warnings
   union {
@@ -218,8 +218,8 @@ static void pluginCache_free(cache_t *cache) {
   pluginCache_params_t *params = (pluginCache_params_t *)cache->eviction_params;
 
   if (params->cache_free_hook != NULL) params->cache_free_hook(params->data);
-  if (params->handle != NULL)
-    dlclose(params->handle);  // Close the plugin shared library handle
+  if (params->plugin_handle != NULL)
+    dlclose(params->plugin_handle);  // Close the plugin shared library handle
   if (params->plugin_path != NULL) free(params->plugin_path);
   if (params->cache_name != NULL) free(params->cache_name);
   free(cache->eviction_params);

--- a/libCacheSim/cache/eviction/plugin_cache.c
+++ b/libCacheSim/cache/eviction/plugin_cache.c
@@ -47,6 +47,7 @@ extern "C" {
  */
 typedef struct pluginCache_params {
   char *plugin_path;                  ///< Path to the plugin shared library
+  void *handle;                       ///< Handle to the loaded plugin library
   void *data;                         ///< Plugin's internal data structure
   cache_init_hook_t cache_init_hook;  ///< Plugin initialization function
   cache_hit_hook_t cache_hit_hook;    ///< Cache hit handler function
@@ -139,6 +140,7 @@ cache_t *pluginCache_init(const common_cache_params_t ccache_params,
     ERROR("Failed to load plugin %s: %s\n", params->plugin_path, dlerror());
     exit(1);
   }
+  params->handle = handle;
 
   // Load hook functions from the plugin using unions to avoid pedantic warnings
   union {
@@ -216,7 +218,8 @@ static void pluginCache_free(cache_t *cache) {
   pluginCache_params_t *params = (pluginCache_params_t *)cache->eviction_params;
 
   if (params->cache_free_hook != NULL) params->cache_free_hook(params->data);
-
+  if (params->handle != NULL)
+    dlclose(params->handle);  // Close the plugin shared library handle
   if (params->plugin_path != NULL) free(params->plugin_path);
   if (params->cache_name != NULL) free(params->cache_name);
   free(cache->eviction_params);
@@ -410,6 +413,12 @@ static void pluginCache_parse_params(cache_t *cache,
 
     // Process recognized parameters
     if (strcasecmp(key, "plugin") == 0 || strcasecmp(key, "plugin_path") == 0) {
+      // Validate plugin path is not empty
+      if (strlen(value) == 0) {
+        ERROR("Parameter 'plugin_path' cannot be empty in cache '%s'\n",
+              cache->cache_name);
+        exit(1);
+      }
       if (params->plugin_path != NULL) free(params->plugin_path);
       params->plugin_path = strdup(value);
     } else if (strcasecmp(key, "cache_name") == 0) {

--- a/libCacheSim/cache/eviction/plugin_cache.c
+++ b/libCacheSim/cache/eviction/plugin_cache.c
@@ -13,6 +13,7 @@
  *   - cache_miss_hook: Handle cache miss events
  *   - cache_eviction_hook: Determine which object to evict
  *   - cache_remove_hook: Clean up when objects are removed
+ *   - cache_free_hook: Free plugin resources
  *
  * The plugin cache delegates core cache operations to these hooks, enabling
  * flexible and extensible cache policies.
@@ -52,6 +53,7 @@ typedef struct pluginCache_params {
   cache_miss_hook_t cache_miss_hook;  ///< Cache miss handler function
   cache_eviction_hook_t cache_eviction_hook;  ///< Eviction decision function
   cache_remove_hook_t cache_remove_hook;  ///< Object removal handler function
+  cache_free_hook_t cache_free_hook;      ///< Cache cleanup function
   char *cache_name;
 } pluginCache_params_t;
 
@@ -159,6 +161,10 @@ cache_t *pluginCache_init(const common_cache_params_t ccache_params,
     void *obj;
     cache_remove_hook_t func;
   } cache_remove_u;
+  union {
+    void *obj;
+    cache_free_hook_t func;
+  } cache_free_u;
 
   cache_init_u.obj = dlsym(handle, "cache_init_hook");
   params->cache_init_hook = cache_init_u.func;
@@ -174,6 +180,9 @@ cache_t *pluginCache_init(const common_cache_params_t ccache_params,
 
   cache_remove_u.obj = dlsym(handle, "cache_remove_hook");
   params->cache_remove_hook = cache_remove_u.func;
+
+  cache_free_u.obj = dlsym(handle, "cache_free_hook");
+  params->cache_free_hook = cache_free_u.func;
 
   // Initialize the plugin with cache parameters
   params->data = params->cache_init_hook(ccache_params);
@@ -205,6 +214,9 @@ cache_t *pluginCache_init(const common_cache_params_t ccache_params,
  */
 static void pluginCache_free(cache_t *cache) {
   pluginCache_params_t *params = (pluginCache_params_t *)cache->eviction_params;
+
+  if (params->cache_free_hook != NULL) params->cache_free_hook(params->data);
+
   if (params->plugin_path != NULL) free(params->plugin_path);
   if (params->cache_name != NULL) free(params->cache_name);
   free(cache->eviction_params);
@@ -398,8 +410,10 @@ static void pluginCache_parse_params(cache_t *cache,
 
     // Process recognized parameters
     if (strcasecmp(key, "plugin") == 0 || strcasecmp(key, "plugin_path") == 0) {
+      if (params->plugin_path != NULL) free(params->plugin_path);
       params->plugin_path = strdup(value);
     } else if (strcasecmp(key, "cache_name") == 0) {
+      if (params->cache_name != NULL) free(params->cache_name);
       params->cache_name = strdup(value);
     } else if (strcasecmp(key, "print") == 0) {
       printf("current parameters: plugin_path=%s\n", params->plugin_path);

--- a/libCacheSim/include/libCacheSim/plugin.h
+++ b/libCacheSim/include/libCacheSim/plugin.h
@@ -109,6 +109,7 @@ cache_t *create_cache_external(const char *const cache_alg_name,
  * - cache_miss_hook: Handle cache miss events
  * - cache_eviction_hook: Determine which object to evict
  * - cache_remove_hook: Clean up when objects are removed
+ * - cache_free_hook: Free plugin resources
  *
  * @see example/plugin_v2/plugin_lru.c for a complete implementation example
  * @{
@@ -185,6 +186,16 @@ typedef obj_id_t (*cache_eviction_hook_t)(void *data, const request_t *req);
  * @note This is called after the object has been removed from the cache
  */
 typedef void (*cache_remove_hook_t)(void *data, const obj_id_t obj_id);
+
+/**
+ * @brief Cache free hook function type
+ *
+ * Optional cleanup function called when the cache is being destroyed.
+ * The plugin should free any resources allocated in cache_init_hook.
+ *
+ * @param data Pointer to plugin's internal data (from cache_init_hook)
+ */
+typedef void (*cache_free_hook_t)(void *data);
 
 /** @} */  // end of v2_plugin_api group
 

--- a/libCacheSim/include/libCacheSim/plugin.h
+++ b/libCacheSim/include/libCacheSim/plugin.h
@@ -190,7 +190,7 @@ typedef void (*cache_remove_hook_t)(void *data, const obj_id_t obj_id);
 /**
  * @brief Cache free hook function type
  *
- * Optional cleanup function called when the cache is being destroyed.
+ * Cleanup function called when the cache is being destroyed.
  * The plugin should free any resources allocated in cache_init_hook.
  *
  * @param data Pointer to plugin's internal data (from cache_init_hook)


### PR DESCRIPTION
Subsequent PR of #252, aimed at better memory management

- Free the default parameter
- Add `cahce_free_hook`