### PR TITLE
Refactor: Rename variables to fix compiler error 

### DIFF
--- a/libCacheSim/cache/eviction/QDLP.c
+++ b/libCacheSim/cache/eviction/QDLP.c
@@ -331,25 +331,25 @@ static cache_obj_t *QDLP_to_evict(cache_t *cache, const request_t *req) {
 static void QDLP_evict(cache_t *cache, const request_t *req) {
   QDLP_params_t *params = (QDLP_params_t *)cache->eviction_params;
 
-  cache_t *fifo = params->fifo;
-  cache_t *ghost = params->fifo_ghost;
-  cache_t *main = params->main_cache;
+  cache_t *small_fifo = params->fifo;
+  cache_t *ghost_fifo = params->fifo_ghost;
+  cache_t *main_cache = params->main_cache;
 
-  if (fifo->get_occupied_byte(fifo) == 0) {
+  if (small_fifo->get_occupied_byte(small_fifo) == 0) {
 #if defined(TRACK_EVICTION_V_AGE)
-    cache_obj_t *obj = main->to_evict(main, req);
+    cache_obj_t *obj = main_cache->to_evict(main_cache, req);
     record_eviction_age(cache, obj, CURR_TIME(cache, req) - obj->create_time);
 #endif
 
-    assert(main->get_occupied_byte(main) <= cache->cache_size);
+    assert(main_cache->get_occupied_byte(main_cache) <= cache->cache_size);
     // evict from main cache
-    main->evict(main, req);
+    main_cache->evict(main_cache, req);
 
     return;
   }
 
   // evict from FIFO
-  cache_obj_t *obj = fifo->to_evict(fifo, req);
+  cache_obj_t *obj = small_fifo->to_evict(small_fifo, req);
   assert(obj != NULL);
   // need to copy the object before it is evicted
   copy_cache_obj_to_request(params->req_local, obj);
@@ -361,21 +361,22 @@ static void QDLP_evict(cache_t *cache, const request_t *req) {
 
     params->main_cache->get(params->main_cache, params->req_local);
 #if defined(TRACK_EVICTION_V_AGE)
-    main->find(main, params->req_local, false)->create_time = obj->create_time;
+    main_cache->find(main_cache, params->req_local, false)->create_time =
+        obj->create_time;
   } else {
     record_eviction_age(cache, obj, CURR_TIME(cache, req) - obj->create_time);
 #else
   } else {
 #endif
     // insert to ghost
-    if (ghost != NULL) {
-      ghost->get(ghost, params->req_local);
+    if (ghost_fifo != NULL) {
+      ghost_fifo->get(ghost_fifo, params->req_local);
     }
   }
 
   // remove from fifo, but do not update stat
   // bool removed = fifo->remove(fifo, params->req_local->obj_id);
-  fifo->evict(fifo, req);
+  small_fifo->evict(small_fifo, req);
 }
 
 /**

--- a/libCacheSim/cache/eviction/S3FIFO.c
+++ b/libCacheSim/cache/eviction/S3FIFO.c
@@ -256,24 +256,24 @@ static cache_obj_t *S3FIFO_insert(cache_t *cache, const request_t *req) {
   S3FIFO_params_t *params = (S3FIFO_params_t *)cache->eviction_params;
   cache_obj_t *obj = NULL;
 
-  cache_t *small = params->small_fifo;
-  cache_t *main = params->main_fifo;
+  cache_t *small_fifo = params->small_fifo;
+  cache_t *main_fifo = params->main_fifo;
 
   if (params->hit_on_ghost) {
     /* insert into main FIFO */
     params->hit_on_ghost = false;
-    obj = main->insert(main, req);
+    obj = main_fifo->insert(main_fifo, req);
   } else {
     /* insert into small fifo */
-    if (req->obj_size >= small->cache_size) {
+    if (req->obj_size >= small_fifo->cache_size) {
       return NULL;
     }
 
     if (!params->has_evicted &&
-        small->get_occupied_byte(small) >= small->cache_size) {
-      obj = main->insert(main, req);
+        small_fifo->get_occupied_byte(small_fifo) >= small_fifo->cache_size) {
+      obj = main_fifo->insert(main_fifo, req);
     } else {
-      obj = small->insert(small, req);
+      obj = small_fifo->insert(small_fifo, req);
     }
   }
 
@@ -299,19 +299,19 @@ static cache_obj_t *S3FIFO_to_evict(cache_t *cache, const request_t *req) {
 
 static void S3FIFO_evict_small(cache_t *cache, const request_t *req) {
   S3FIFO_params_t *params = (S3FIFO_params_t *)cache->eviction_params;
-  cache_t *small = params->small_fifo;
+  cache_t *small_fifo = params->small_fifo;
   cache_t *ghost = params->ghost_fifo;
-  cache_t *main = params->main_fifo;
+  cache_t *main_fifo = params->main_fifo;
 
   bool has_evicted = false;
-  while (!has_evicted && small->get_occupied_byte(small) > 0) {
-    cache_obj_t *obj_to_evict = small->to_evict(small, req);
+  while (!has_evicted && small_fifo->get_occupied_byte(small_fifo) > 0) {
+    cache_obj_t *obj_to_evict = small_fifo->to_evict(small_fifo, req);
     DEBUG_ASSERT(obj_to_evict != NULL);
     // need to copy the object before it is evicted
     copy_cache_obj_to_request(params->req_local, obj_to_evict);
 
     if (obj_to_evict->S3FIFO.freq >= params->move_to_main_threshold) {
-      main->insert(main, params->req_local);
+      main_fifo->insert(main_fifo, params->req_local);
     } else {
       // insert to ghost
       if (ghost != NULL) {
@@ -321,32 +321,32 @@ static void S3FIFO_evict_small(cache_t *cache, const request_t *req) {
     }
 
     // remove from small fifo, but do not update stat
-    bool removed = small->remove(small, params->req_local->obj_id);
+    bool removed = small_fifo->remove(small_fifo, params->req_local->obj_id);
     DEBUG_ASSERT(removed);
   }
 }
 
 static void S3FIFO_evict_main(cache_t *cache, const request_t *req) {
   S3FIFO_params_t *params = (S3FIFO_params_t *)cache->eviction_params;
-  cache_t *main = params->main_fifo;
+  cache_t *main_fifo = params->main_fifo;
 
   bool has_evicted = false;
-  while (!has_evicted && main->get_occupied_byte(main) > 0) {
-    cache_obj_t *obj_to_evict = main->to_evict(main, req);
+  while (!has_evicted && main_fifo->get_occupied_byte(main_fifo) > 0) {
+    cache_obj_t *obj_to_evict = main_fifo->to_evict(main_fifo, req);
     DEBUG_ASSERT(obj_to_evict != NULL);
     int freq = obj_to_evict->S3FIFO.freq;
     copy_cache_obj_to_request(params->req_local, obj_to_evict);
     if (freq >= 1) {
       // we need to evict first because the object to insert has the same obj_id
-      main->remove(main, obj_to_evict->obj_id);
+      main_fifo->remove(main_fifo, obj_to_evict->obj_id);
       obj_to_evict = NULL;
 
-      cache_obj_t *new_obj = main->insert(main, params->req_local);
+      cache_obj_t *new_obj = main_fifo->insert(main_fifo, params->req_local);
       // clock with 2-bit counter
       new_obj->S3FIFO.freq = MIN(freq, 3) - 1;
 
     } else {
-      bool removed = main->remove(main, obj_to_evict->obj_id);
+      bool removed = main_fifo->remove(main_fifo, obj_to_evict->obj_id);
       DEBUG_ASSERT(removed);
 
       has_evicted = true;
@@ -367,11 +367,11 @@ static void S3FIFO_evict(cache_t *cache, const request_t *req) {
   S3FIFO_params_t *params = (S3FIFO_params_t *)cache->eviction_params;
   params->has_evicted = true;
 
-  cache_t *small = params->small_fifo;
-  cache_t *main = params->main_fifo;
+  cache_t *small_fifo = params->small_fifo;
+  cache_t *main_fifo = params->main_fifo;
 
-  if (main->get_occupied_byte(main) > main->cache_size ||
-      small->get_occupied_byte(small) == 0) {
+  if (main_fifo->get_occupied_byte(main_fifo) > main_fifo->cache_size ||
+      small_fifo->get_occupied_byte(small_fifo) == 0) {
     S3FIFO_evict_main(cache, req);
   } else {
     S3FIFO_evict_small(cache, req);

--- a/libCacheSim/cache/eviction/S3FIFOd.c
+++ b/libCacheSim/cache/eviction/S3FIFOd.c
@@ -399,26 +399,26 @@ static cache_obj_t *S3FIFOd_to_evict(cache_t *cache, const request_t *req) {
 static void S3FIFOd_evict(cache_t *cache, const request_t *req) {
   S3FIFOd_params_t *params = (S3FIFOd_params_t *)cache->eviction_params;
 
-  cache_t *fifo = params->fifo;
+  cache_t *small_fifo = params->fifo;
   cache_t *ghost = params->fifo_ghost;
-  cache_t *main = params->main_cache;
+  cache_t *main_cache = params->main_cache;
 
-  if (fifo->get_occupied_byte(fifo) == 0) {
-    assert(main->get_occupied_byte(main) <= cache->cache_size);
+  if (small_fifo->get_occupied_byte(small_fifo) == 0) {
+    assert(main_cache->get_occupied_byte(main_cache) <= cache->cache_size);
     // evict from main cache
-    cache_obj_t *obj = main->to_evict(main, req);
+    cache_obj_t *obj = main_cache->to_evict(main_cache, req);
 #if defined(TRACK_EVICTION_V_AGE)
     record_eviction_age(cache, obj, CURR_TIME(cache, req) - obj->create_time);
 #endif
     copy_cache_obj_to_request(params->req_local, obj);
     params->main_cache_eviction->get(params->main_cache_eviction,
                                      params->req_local);
-    main->evict(main, req);
+    main_cache->evict(main_cache, req);
     return;
   }
 
   // evict from FIFO
-  cache_obj_t *obj = fifo->to_evict(fifo, req);
+  cache_obj_t *obj = small_fifo->to_evict(small_fifo, req);
   assert(obj != NULL);
   // need to copy the object before it is evicted
   copy_cache_obj_to_request(params->req_local, obj);
@@ -426,23 +426,23 @@ static void S3FIFOd_evict(cache_t *cache, const request_t *req) {
 #if defined(TRACK_EVICTION_V_AGE)
   if (obj->misc.freq >= params->move_to_main_threshold) {
     // promote to main cache
-    cache_obj_t *new_obj = main->insert(main, params->req_local);
+    cache_obj_t *new_obj = main_cache->insert(main_cache, params->req_local);
     new_obj->create_time = obj->create_time;
     // evict from fifo, must be after copy eviction age
-    bool removed = fifo->remove(fifo, params->req_local->obj_id);
+    bool removed = small_fifo->remove(small_fifo, params->req_local->obj_id);
     assert(removed);
 
-    while (main->get_occupied_byte(main) > main->cache_size) {
+    while (main_cache->get_occupied_byte(main_cache) > main_cache->cache_size) {
       // evict from main cache
-      obj = main->to_evict(main, req);
+      obj = main_cache->to_evict(main_cache, req);
       copy_cache_obj_to_request(params->req_local, obj);
       params->main_cache_eviction->get(params->main_cache_eviction,
                                        params->req_local);
-      main->evict(main, req);
+      main_cache->evict(main_cache, req);
     }
   } else {
     // evict from fifo, must be after copy eviction age
-    bool removed = fifo->remove(fifo, params->req_local->obj_id);
+    bool removed = small_fifo->remove(small_fifo, params->req_local->obj_id);
     assert(removed);
 
     record_eviction_age(cache, obj, CURR_TIME(cache, req) - obj->create_time);
@@ -453,20 +453,20 @@ static void S3FIFOd_evict(cache_t *cache, const request_t *req) {
 
 #else
   // evict from fifo
-  bool removed = fifo->remove(fifo, params->req_local->obj_id);
+  bool removed = small_fifo->remove(small_fifo, params->req_local->obj_id);
   assert(removed);
 
   if (obj->misc.freq >= params->move_to_main_threshold) {
     // promote to main cache
-    main->insert(main, params->req_local);
+    main_cache->insert(main_cache, params->req_local);
 
-    while (main->get_occupied_byte(main) > main->cache_size) {
+    while (main_cache->get_occupied_byte(main_cache) > main_cache->cache_size) {
       // evict from main cache
-      obj = main->to_evict(main, req);
+      obj = main_cache->to_evict(main_cache, req);
       copy_cache_obj_to_request(params->req_local, obj);
       params->main_cache_eviction->get(params->main_cache_eviction,
                                        params->req_local);
-      main->evict(main, req);
+      main_cache->evict(main_cache, req);
     }
   } else {
     // insert to ghost

--- a/libCacheSim/cache/eviction/S3FIFOv0.c
+++ b/libCacheSim/cache/eviction/S3FIFOv0.c
@@ -211,16 +211,16 @@ static cache_obj_t *S3FIFOv0_find(cache_t *cache, const request_t *req,
                                   const bool update_cache) {
   S3FIFOv0_params_t *params = (S3FIFOv0_params_t *)cache->eviction_params;
 
-  cache_t *small = params->small_fifo;
-  cache_t *main = params->main_fifo;
+  cache_t *small_fifo = params->small_fifo;
+  cache_t *main_fifo = params->main_fifo;
 
   // if update cache is false, we only check the fifo and main caches
   if (!update_cache) {
-    cache_obj_t *obj = small->find(small, req, false);
+    cache_obj_t *obj = small_fifo->find(small_fifo, req, false);
     if (obj != NULL) {
       return obj;
     }
-    obj = main->find(main, req, false);
+    obj = main_fifo->find(main_fifo, req, false);
     if (obj != NULL) {
       return obj;
     }
@@ -229,7 +229,7 @@ static cache_obj_t *S3FIFOv0_find(cache_t *cache, const request_t *req,
 
   /* update cache is true from now */
   params->hit_on_ghost = false;
-  cache_obj_t *obj = small->find(small, req, true);
+  cache_obj_t *obj = small_fifo->find(small_fifo, req, true);
   if (obj != NULL) {
     obj->S3FIFO.freq += 1;
     return obj;
@@ -241,7 +241,7 @@ static cache_obj_t *S3FIFOv0_find(cache_t *cache, const request_t *req,
     params->hit_on_ghost = true;
   }
 
-  obj = main->find(main, req, true);
+  obj = main_fifo->find(main_fifo, req, true);
   if (obj != NULL) {
     obj->S3FIFO.freq += 1;
   }
@@ -310,14 +310,14 @@ static cache_obj_t *S3FIFOv0_to_evict(cache_t *cache, const request_t *req) {
 
 static void S3FIFOv0_evict_small(cache_t *cache, const request_t *req) {
   S3FIFOv0_params_t *params = (S3FIFOv0_params_t *)cache->eviction_params;
-  cache_t *small = params->small_fifo;
-  cache_t *ghost = params->ghost_fifo;
-  cache_t *main = params->main_fifo;
+  cache_t *small_fifo = params->small_fifo;
+  cache_t *ghost_fifo = params->ghost_fifo;
+  cache_t *main_fifo = params->main_fifo;
 
   bool has_evicted = false;
-  while (!has_evicted && small->get_occupied_byte(small) > 0) {
+  while (!has_evicted && small_fifo->get_occupied_byte(small_fifo) > 0) {
     // evict from small fifo
-    cache_obj_t *obj_to_evict = small->to_evict(small, req);
+    cache_obj_t *obj_to_evict = small_fifo->to_evict(small_fifo, req);
     DEBUG_ASSERT(obj_to_evict != NULL);
     // need to copy the object before it is evicted
     copy_cache_obj_to_request(params->req_local, obj_to_evict);
@@ -330,7 +330,7 @@ static void S3FIFOv0_evict_small(cache_t *cache, const request_t *req) {
       params->n_obj_move_to_main += 1;
       params->n_byte_move_to_main += obj_to_evict->obj_size;
 
-      cache_obj_t *new_obj = main->insert(main, params->req_local);
+      cache_obj_t *new_obj = main_fifo->insert(main_fifo, params->req_local);
 #if defined(TRACK_EVICTION_V_AGE)
       new_obj->create_time = obj_to_evict->create_time;
     } else {
@@ -346,26 +346,26 @@ static void S3FIFOv0_evict_small(cache_t *cache, const request_t *req) {
 #endif
 
       // insert to ghost
-      if (ghost != NULL) {
-        ghost->get(ghost, params->req_local);
+      if (ghost_fifo != NULL) {
+        ghost_fifo->get(ghost_fifo, params->req_local);
       }
       has_evicted = true;
     }
 
     // remove from fifo, but do not update stat
-    bool removed = small->remove(small, params->req_local->obj_id);
+    bool removed = small_fifo->remove(small_fifo, params->req_local->obj_id);
     DEBUG_ASSERT(removed);
   }
 }
 
 static void S3FIFOv0_evict_main(cache_t *cache, const request_t *req) {
   S3FIFOv0_params_t *params = (S3FIFOv0_params_t *)cache->eviction_params;
-  cache_t *main = params->main_fifo;
+  cache_t *main_fifo = params->main_fifo;
 
   // evict from main cache
   bool has_evicted = false;
-  while (!has_evicted && main->get_occupied_byte(main) > 0) {
-    cache_obj_t *obj_to_evict = main->to_evict(main, req);
+  while (!has_evicted && main_fifo->get_occupied_byte(main_fifo) > 0) {
+    cache_obj_t *obj_to_evict = main_fifo->to_evict(main_fifo, req);
     DEBUG_ASSERT(obj_to_evict != NULL);
     int freq = obj_to_evict->S3FIFO.freq;
 #if defined(TRACK_EVICTION_V_AGE)
@@ -374,10 +374,10 @@ static void S3FIFOv0_evict_main(cache_t *cache, const request_t *req) {
     copy_cache_obj_to_request(params->req_local, obj_to_evict);
     if (freq >= 1) {
       // we need to evict first because the object to insert has the same obj_id
-      main->remove(main, obj_to_evict->obj_id);
+      main_fifo->remove(main_fifo, obj_to_evict->obj_id);
       obj_to_evict = NULL;
 
-      cache_obj_t *new_obj = main->insert(main, params->req_local);
+      cache_obj_t *new_obj = main_fifo->insert(main_fifo, params->req_local);
       // clock with 2-bit counter
       new_obj->S3FIFO.freq = MIN(freq, 3) - 1;
 
@@ -390,7 +390,7 @@ static void S3FIFOv0_evict_main(cache_t *cache, const request_t *req) {
                           CURR_TIME(cache, req) - obj_to_evict->create_time);
 #endif
 
-      bool removed = main->remove(main, obj_to_evict->obj_id);
+      bool removed = main_fifo->remove(main_fifo, obj_to_evict->obj_id);
       DEBUG_ASSERT(removed);
 
       has_evicted = true;
@@ -410,11 +410,11 @@ static void S3FIFOv0_evict_main(cache_t *cache, const request_t *req) {
 static void S3FIFOv0_evict(cache_t *cache, const request_t *req) {
   S3FIFOv0_params_t *params = (S3FIFOv0_params_t *)cache->eviction_params;
 
-  cache_t *fifo = params->small_fifo;
-  cache_t *main = params->main_fifo;
+  cache_t *small_fifo = params->small_fifo;
+  cache_t *main_fifo = params->main_fifo;
 
-  if (main->get_occupied_byte(main) > main->cache_size ||
-      fifo->get_occupied_byte(fifo) == 0) {
+  if (main_fifo->get_occupied_byte(main_fifo) > main_fifo->cache_size ||
+      small_fifo->get_occupied_byte(small_fifo) == 0) {
     S3FIFOv0_evict_main(cache, req);
   } else {
     S3FIFOv0_evict_small(cache, req);

--- a/libCacheSim/cache/eviction/WTinyLFU.c
+++ b/libCacheSim/cache/eviction/WTinyLFU.c
@@ -261,7 +261,7 @@ static void WTinyLFU_evict(cache_t *cache, const request_t *req) {
   WTinyLFU_params_t *params = (WTinyLFU_params_t *)(cache->eviction_params);
 
   cache_t *window = params->LRU;
-  cache_t *main = params->main_cache;
+  cache_t *main_cache = params->main_cache;
 
   bool evicted = false;
   while (!evicted) {
@@ -275,10 +275,10 @@ static void WTinyLFU_evict(cache_t *cache, const request_t *req) {
       /** only when main_cache is full, evict an obj from the main_cache **/
 
       // if main_cache has enough space, insert the obj into main_cache
-      if (main->get_occupied_byte(main) + params->req_local->obj_size +
-              cache->obj_md_size <=
-          main->cache_size) {
-        main->insert(main, params->req_local);
+      if (main_cache->get_occupied_byte(main_cache) +
+              params->req_local->obj_size + cache->obj_md_size <=
+          main_cache->cache_size) {
+        main_cache->insert(main_cache, params->req_local);
 
 #if defined(TRACK_DEMOTION)
         printf("%ld keep %ld %ld\n", cache->n_req, window_victim->create_time,
@@ -290,7 +290,7 @@ static void WTinyLFU_evict(cache_t *cache, const request_t *req) {
 
       } else {
         // compare the frequency of window_victim and main_cache_victim
-        cache_obj_t *main_cache_victim = main->to_evict(main, req);
+        cache_obj_t *main_cache_victim = main_cache->to_evict(main_cache, req);
         DEBUG_ASSERT(main_cache_victim != NULL);
         // if window_victim is more frequent, insert it into main_cache
         if (minimalIncrementCBF_estimate(params->CBF,
@@ -304,12 +304,13 @@ static void WTinyLFU_evict(cache_t *cache, const request_t *req) {
                  window_victim->misc.next_access_vtime);
 #endif
 
-          main->evict(main, req);
+          main_cache->evict(main_cache, req);
 
           bool ret = window->remove(window, window_victim->obj_id);
           DEBUG_ASSERT(ret);
 
-          cache_obj_t *cache_obj = main->insert(main, params->req_local);
+          cache_obj_t *cache_obj =
+              main_cache->insert(main_cache, params->req_local);
           params->n_admit_bytes += params->req_local->obj_size;
 
         } else {
@@ -328,7 +329,7 @@ static void WTinyLFU_evict(cache_t *cache, const request_t *req) {
                               sizeof(obj_id_t));
     } else {
       DEBUG_ASSERT(window->get_occupied_byte(window) == 0);
-      main->evict(main, req);
+      main_cache->evict(main_cache, req);
       return;
     }
   }

--- a/libCacheSim/cache/eviction/other/S3LRU.c
+++ b/libCacheSim/cache/eviction/other/S3LRU.c
@@ -325,7 +325,7 @@ static void S3LRU_evict_LRU(cache_t *cache, const request_t *req) {
   S3LRU_params_t *params = (S3LRU_params_t *)cache->eviction_params;
   cache_t *LRU = params->LRU;
   cache_t *ghost = params->LRU_ghost;
-  cache_t *main = params->main_cache;
+  cache_t *main_cache = params->main_cache;
 
   bool has_evicted = false;
 
@@ -341,7 +341,7 @@ static void S3LRU_evict_LRU(cache_t *cache, const request_t *req) {
              obj_to_evict->misc.next_access_vtime);
 #endif
 
-      main->insert(main, params->req_local);
+      main_cache->insert(main_cache, params->req_local);
     } else {
 #if defined(TRACK_DEMOTION)
       printf("%ld demote %ld %ld\n", cache->n_req, obj_to_evict->create_time,
@@ -362,14 +362,14 @@ static void S3LRU_evict_main(cache_t *cache, const request_t *req) {
   S3LRU_params_t *params = (S3LRU_params_t *)cache->eviction_params;
   // cache_t *LRU = params->LRU;
   // cache_t *ghost = params->LRU_ghost;
-  cache_t *main = params->main_cache;
+  cache_t *main_cache = params->main_cache;
 
   // evict from main cache
   bool has_evicted = false;
-  while (!has_evicted && main->get_occupied_byte(main) > 0) {
-    cache_obj_t *obj_to_evict = main->to_evict(main, req);
+  while (!has_evicted && main_cache->get_occupied_byte(main_cache) > 0) {
+    cache_obj_t *obj_to_evict = main_cache->to_evict(main_cache, req);
     DEBUG_ASSERT(obj_to_evict != NULL);
-    bool removed = main->remove(main, obj_to_evict->obj_id);
+    bool removed = main_cache->remove(main_cache, obj_to_evict->obj_id);
     if (!removed) {
       ERROR("cannot remove obj %ld\n", (long)obj_to_evict->obj_id);
     }
@@ -391,11 +391,11 @@ static void S3LRU_evict(cache_t *cache, const request_t *req) {
   S3LRU_params_t *params = (S3LRU_params_t *)cache->eviction_params;
 
   cache_t *LRU = params->LRU;
-  cache_t *main = params->main_cache;
+  cache_t *main_cache = params->main_cache;
 
-  if (main->get_occupied_byte(main) > main->cache_size ||
+  if (main_cache->get_occupied_byte(main_cache) > main_cache->cache_size ||
       LRU->get_occupied_byte(LRU) == 0) {
-    main->evict(main, req);
+    main_cache->evict(main_cache, req);
     return;
   } else {
     S3LRU_evict_LRU(cache, req);


### PR DESCRIPTION
some compiler complains that "main" should not be used as a variable name

- Updated variable names in QDLP, S3FIFO, S3FIFOd, S3FIFOv0, WTinyLFU, and S3LRU eviction algorithms to improve code readability.
- Changed 'fifo' to 'small_fifo' and 'main' to 'main_cache' for consistency across the codebase.
- Ensured that all references to cache objects are clear and descriptive, enhancing maintainability.