### PR TITLE
[BUG]: Avoid nullptr access and subsequent deref

### DIFF
--- a/libCacheSim/include/libCacheSim/enum.h
+++ b/libCacheSim/include/libCacheSim/enum.h
@@ -99,8 +99,8 @@ static const char* const req_op_str[OP_INVALID + 2] = {
     "prepend", "delete",
     "incr",    "decr",
     "read",    "write",
-    "update",  INV_X64 INV_X64 INV_X64 INV_X16 INV_X16 INV_X16
-    "invalid", "invalid"};
+    "update",  INV_X64 INV_X64 INV_X64 INV_X16 INV_X16 INV_X16 "invalid",
+    "invalid"};
 
 typedef enum { ERR, OK, MY_EOF } rstatus;
 static const char* const rstatus_str[3] = {"ERR", "OK", "MY_EOF"};

--- a/libCacheSim/include/libCacheSim/enum.h
+++ b/libCacheSim/include/libCacheSim/enum.h
@@ -86,9 +86,17 @@ typedef enum {
   OP_INVALID = 255
 } req_op_e;
 
+#define INV "invalid",
+#define INV_X16 INV INV INV INV INV INV INV INV INV INV INV INV INV INV INV INV
+#define INV_X64 INV_X16 INV_X16 INV_X16 INV_X16
+#define INV_X256 INV_X64 INV_X64 INV_X64 INV_X64
+
 static const char* const req_op_str[OP_INVALID + 2] = {
-    "nop",     "get",    "gets", "set",  "add",  "cas",   "replace", "append",
-    "prepend", "delete", "incr", "decr", "read", "write", "update",  "invalid"};
+    "nop",     "get",    "gets",    "set",
+    "add",     "cas",    "replace", "append",
+    "prepend", "delete", "incr",    "decr",
+    "read",    "write",  "update",  INV_X64 INV_X64 INV_X64 INV_X48,
+    "invalid", "invalid"};
 
 typedef enum { ERR, OK, MY_EOF } rstatus;
 static const char* const rstatus_str[3] = {"ERR", "OK", "MY_EOF"};

--- a/libCacheSim/include/libCacheSim/enum.h
+++ b/libCacheSim/include/libCacheSim/enum.h
@@ -92,10 +92,14 @@ typedef enum {
 #define INV_X256 INV_X64 INV_X64 INV_X64 INV_X64
 
 static const char* const req_op_str[OP_INVALID + 2] = {
-    "nop",     "get",    "gets",    "set",
-    "add",     "cas",    "replace", "append",
-    "prepend", "delete", "incr",    "decr",
-    "read",    "write",  "update",  INV_X64 INV_X64 INV_X64 INV_X48,
+    "nop",     "get",
+    "gets",    "set",
+    "add",     "cas",
+    "replace", "append",
+    "prepend", "delete",
+    "incr",    "decr",
+    "read",    "write",
+    "update",  INV_X64 INV_X64 INV_X64 INV_X16 INV_X16 INV_X16
     "invalid", "invalid"};
 
 typedef enum { ERR, OK, MY_EOF } rstatus;


### PR DESCRIPTION
In Analyzer, we will output op str, the nullptr will cause an error when deref


15 valid str + 242 invalid str