### PR TITLE
Let LHD_insert return dummy (not NULL) cache obj ptr

### DIFF
--- a/libCacheSim/cache/eviction/LHD/LHD_Interface.cpp
+++ b/libCacheSim/cache/eviction/LHD/LHD_Interface.cpp
@@ -12,6 +12,12 @@ using namespace repl;
 extern "C" {
 #endif
 
+// NOTE: Since LHD uses internal data struct to reprensent cache_obj_t, to suit
+// the interface, we use a dummy pointer to represent the cache_obj_t.
+// Specifically, for find and insert, we return a dummy pointer when the object
+// is found or inserted and NULL when the object is not found.
+static cache_obj_t* const DUMMY_CACHE_OBJ_PTR = reinterpret_cast<cache_obj_t*>(1);
+
 typedef struct {
   void *LHD_cache;
 
@@ -176,7 +182,7 @@ static cache_obj_t *LHD_find(cache_t *cache, const request_t *req,
     lhd->update(id, req);
   }
 
-  return reinterpret_cast<cache_obj_t *>(0x1);
+  return DUMMY_CACHE_OBJ_PTR;
 }
 
 /**
@@ -205,7 +211,7 @@ static cache_obj_t *LHD_insert(cache_t *cache, const request_t *req) {
   cache->occupied_byte += req->obj_size + cache->obj_md_size;
   cache->n_obj += 1;
 
-  return reinterpret_cast<cache_obj_t *>(0x1);
+  return DUMMY_CACHE_OBJ_PTR;
 }
 
 /**

--- a/libCacheSim/cache/eviction/LHD/LHD_Interface.cpp
+++ b/libCacheSim/cache/eviction/LHD/LHD_Interface.cpp
@@ -205,7 +205,7 @@ static cache_obj_t *LHD_insert(cache_t *cache, const request_t *req) {
   cache->occupied_byte += req->obj_size + cache->obj_md_size;
   cache->n_obj += 1;
 
-  return NULL;
+  return reinterpret_cast<cache_obj_t *>(0x1);
 }
 
 /**

--- a/libCacheSim/cache/eviction/LHD/LHD_Interface.cpp
+++ b/libCacheSim/cache/eviction/LHD/LHD_Interface.cpp
@@ -16,7 +16,8 @@ extern "C" {
 // the interface, we use a dummy pointer to represent the cache_obj_t.
 // Specifically, for find and insert, we return a dummy pointer when the object
 // is found or inserted and NULL when the object is not found.
-static cache_obj_t* const DUMMY_CACHE_OBJ_PTR = reinterpret_cast<cache_obj_t*>(1);
+static cache_obj_t *const DUMMY_CACHE_OBJ_PTR =
+    reinterpret_cast<cache_obj_t *>(1);
 
 typedef struct {
   void *LHD_cache;


### PR DESCRIPTION
To match the doc, related to #286 :

#### Cache insert
This is the lower level cache API, which tries to insert the object in the cache. If the object can be inserted into the cache, it returns the inserted object. Otherwise, it returns NULL.

Note that there are cases that the object is not inserted into the cache, e.g., the object is too large to fit in the cache.

Because this is the second level API, this function does not perform eviction and assumes the cache has enough space.
If using this function, you need to explicitly call `evict` to evict objects.
```c
cache->insert(cache, req);
```