### PR TITLE
[Fix] TwoQ crashes when the LRU cache is empty

### DIFF
--- a/libCacheSim/cache/eviction/TwoQ.c
+++ b/libCacheSim/cache/eviction/TwoQ.c
@@ -259,7 +259,11 @@ static void TwoQ_evict(cache_t *cache, const request_t *req) {
   cache_t *Aout = params->Aout;
   cache_t *Am = params->Am;
 
-  if (Ain->get_occupied_byte(Ain) > params->Ain_cache_size) {
+  if (Am->get_occupied_byte(Am) > 0 &&
+      Ain->get_occupied_byte(Ain) <= params->Ain_cache_size) {
+    // evict from Am
+    Am->evict(Am, req);
+  } else {
     // evict from Ain cache
     cache_obj_t *obj = Ain->to_evict(Ain, req);
     assert(obj != NULL);
@@ -267,11 +271,7 @@ static void TwoQ_evict(cache_t *cache, const request_t *req) {
     copy_cache_obj_to_request(params->req_local, obj);
     Aout->get(Aout, params->req_local);
     Ain->evict(Ain, req);
-    return;
   }
-
-  // evict from Am
-  Am->evict(Am, req);
 }
 
 /**

--- a/scripts/install_dependency.sh
+++ b/scripts/install_dependency.sh
@@ -124,7 +124,7 @@ setup_macOS() {
 		log_error "Homebrew is not installed. Please install Homebrew first."
 		exit 1
 	fi
-	brew install glib google-perftools argp-standalone xxhash llvm wget cmake ninja zstd xgboost lightgbm
+	brew install glib google-perftools argp-standalone xxhash llvm wget cmake ninja zstd xgboost lightgbm pkgconf
 }
 
 # Install CMake


### PR DESCRIPTION
When `TwoQ_evict` is called while Ain is within the size limit, the function will try to do eviction on Am. But when Am is empty, an assertion failure will be encountered.

This PR also explicitly install the pkgconf to avoid the dependency issue on current macos.