### PR TITLE
Fix initialization crash for WTinyLFU when parameters are empty

### DIFF
--- a/libCacheSim/bin/cachesim/cache_init.h
+++ b/libCacheSim/bin/cachesim/cache_init.h
@@ -103,8 +103,8 @@ static inline cache_t *create_cache(const char *trace_path,
     cc_params.hashpower = MAX(cc_params.hashpower - 8, 16);
     cache = Hyperbolic_init(cc_params, eviction_params);
   } else if (strcasecmp(eviction_algo, "tinyLFU") == 0) {
-    if (eviction_params == NULL) {
-      cache = WTinyLFU_init(cc_params, eviction_params);
+    if (eviction_params == NULL || eviction_params[0] == '\0') { 
+      cache = WTinyLFU_init(cc_params, "window-size=0.01");
     } else {
       const char *window_size = strstr(eviction_params, "window-size=");
       if (window_size == NULL) {

--- a/libCacheSim/bin/cachesim/cache_init.h
+++ b/libCacheSim/bin/cachesim/cache_init.h
@@ -103,8 +103,8 @@ static inline cache_t *create_cache(const char *trace_path,
     cc_params.hashpower = MAX(cc_params.hashpower - 8, 16);
     cache = Hyperbolic_init(cc_params, eviction_params);
   } else if (strcasecmp(eviction_algo, "tinyLFU") == 0) {
-    if (eviction_params == NULL || eviction_params[0] == '\0') { 
-      cache = WTinyLFU_init(cc_params, "window-size=0.01");
+    if (eviction_params == NULL || eviction_params[0] == '\0') {
+      cache = WTinyLFU_init(cc_params, NULL);
     } else {
       const char *window_size = strstr(eviction_params, "window-size=");
       if (window_size == NULL) {


### PR DESCRIPTION
## Description:
This PR fixes an abort error that occurs when WTinyLFU is initialized with an empty parameter string (e.g., using the `-e ""` flag in the CLI).

The issue was located in `cache_init.h`, where the code attempted to append default parameters to the user input. When the input was empty, the code produced a malformed string with a leading comma: `",window-size=0.01"`

## Changes:
Updated the logic in `bin/cachesim/cache_init.h` to check if eviction_params is NULL or an empty string ("").

If empty, it now passes a clean default string (`"window-size=0.01"`) without a leading comma.

This ensures the initialization sequence is syntactically correct for the internal parser.

## Verification:
### Command:
``` (libCacheSim) libCacheSim/_build (libCacheSim) % ./bin/cachesim ../data/cloudPhysicsIO.txt txt tinyLFU 100M -e "" ```
### Before:
```               
[ERROR] 01-21-2026 15:16:29 WTinyLFU.c:376  (tid=8514739968): WTinyLFU does not have parameter ,window-size                     
```
### After:
```               
[INFO]  01-21-2026 15:28:06 cli_parser.c:559  (tid=8514739968): trace path: ../data/cloudPhysicsIO.txt, trace_type PLAIN_TXT_TRA
CE, ofilepath result/cloudPhysicsIO.txt.cachesim, 12 threads, warmup -1 sec, total 1 algo x 1 size = 1 caches, tinyLFU, eviction
-params:                                                                                                                        
[DEBUG] 01-21-2026 15:28:06 request.h:128  (tid=8514739968): req clock_time 0, id 1, size 1, op nop, valid 1                    
[DEBUG] 01-21-2026 15:28:06 request.h:128  (tid=8514739968): req clock_time 0, id 2, size 1, op nop, valid 1                    
../data/cloudPhysicsIO.txt WTinyLFU-w0.01-SLRU cache size   100MiB,           113872 req, miss ratio 0.4301, throughput 0.21 MQPS ```
