### PR TITLE
add size_probabilistic admission algorithm

### DIFF
--- a/libCacheSim/cache/admission/CMakeLists.txt
+++ b/libCacheSim/cache/admission/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(admissionC prob.c size.c bloomfilter.c)
+add_library(admissionC prob.c size.c bloomfilter.c sizeProbabilistic.c)
 add_library(admissionCpp adaptsize.cpp)
 
 

--- a/libCacheSim/cache/admission/sizeProbabilistic.c
+++ b/libCacheSim/cache/admission/sizeProbabilistic.c
@@ -1,0 +1,110 @@
+//
+// Created by Juncheng on 10/29/24.
+//
+// size-probabilistic admission is a probabilistic admission that
+// also considers object size, larger objects have lower probabilities
+// to be admitted
+// the probability for admitting an object of size S is e^(-exponent * S)
+//
+
+#include <math.h>
+
+#include "../../include/libCacheSim/admissionAlgo.h"
+#include "../../utils/include/mymath.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MAX_MODULE 10000000
+
+typedef struct size_probabilistic_admissioner {
+  double exponent;
+} size_probabilistic_admission_params_t;
+
+bool size_probabilistic_admit(admissioner_t *admissioner, const request_t *req) {
+  size_probabilistic_admission_params_t *pa = (size_probabilistic_admission_params_t *)admissioner->params;
+  double prob = exp(-pa->exponent * (double)req->obj_size);
+  if ((double)(next_rand() % MAX_MODULE) / (double)MAX_MODULE < prob) {
+    return true;
+  }
+
+  return false;
+}
+
+static void size_probabilistic_admissioner_parse_params(const char *init_params,
+                                                        size_probabilistic_admission_params_t *pa) {
+  if (init_params == NULL) {
+    pa->exponent = 1e-6;
+    INFO("use default admission exponent: %f\n", pa->exponent);
+  } else {
+    char *params_str = strdup(init_params);
+    char *old_params_str = params_str;
+    char *end;
+
+    while (params_str != NULL && params_str[0] != '\0') {
+      /* different parameters are separated by comma,
+       * key and value are separated by = */
+      char *key = strsep((char **)&params_str, "=");
+      char *value = strsep((char **)&params_str, ",");
+
+      // skip the white space
+      while (params_str != NULL && *params_str == ' ') {
+        params_str++;
+      }
+
+      if (strcasecmp(key, "exponent") == 0) {
+        pa->exponent = strtod(value, &end);
+        if (strlen(end) > 2) {
+          ERROR("param parsing error, find string \"%s\" after number\n", end);
+        }
+        INFO("use admission exponent: %f\n", pa->exponent);
+      } else {
+        ERROR("size-probabilistic admission does not have parameter %s\n", key);
+      }
+    }
+    free(old_params_str);
+  }
+
+  if (pa->exponent > 1 || pa->exponent <= 0) {
+    ERROR(
+        "size-probabilistic admissioner calculates probability e^(-exponent * obj_size) to admit object, a common "
+        "exponent should be 0-1, e.g., 1e-6, but input %lf\n",
+        pa->exponent);
+  }
+}
+
+admissioner_t *clone_size_probabilistic_admissioner(admissioner_t *admissioner) {
+  return create_size_probabilistic_admissioner(admissioner->init_params);
+}
+
+void free_size_probabilistic_admissioner(admissioner_t *admissioner) {
+  size_probabilistic_admission_params_t *pa = admissioner->params;
+
+  free(pa);
+  if (admissioner->init_params) {
+    free(admissioner->init_params);
+  }
+  free(admissioner);
+}
+
+admissioner_t *create_size_probabilistic_admissioner(const char *init_params) {
+  size_probabilistic_admission_params_t *pa =
+      (size_probabilistic_admission_params_t *)malloc(sizeof(size_probabilistic_admission_params_t));
+  memset(pa, 0, sizeof(size_probabilistic_admission_params_t));
+  size_probabilistic_admissioner_parse_params(init_params, pa);
+
+  admissioner_t *admissioner = (admissioner_t *)malloc(sizeof(admissioner_t));
+  memset(admissioner, 0, sizeof(admissioner_t));
+  admissioner->params = pa;
+  admissioner->admit = size_probabilistic_admit;
+  admissioner->free = free_size_probabilistic_admissioner;
+  admissioner->clone = clone_size_probabilistic_admissioner;
+  if (init_params != NULL) admissioner->init_params = strdup(init_params);
+
+  return admissioner;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/libCacheSim/include/libCacheSim/admissionAlgo.h
+++ b/libCacheSim/include/libCacheSim/admissionAlgo.h
@@ -9,7 +9,7 @@ extern "C" {
 struct admissioner;
 typedef struct admissioner *(*admissioner_create_func_ptr)(const char *);
 typedef struct admissioner *(*admissioner_clone_func_ptr)(struct admissioner *);
-typedef bool (*cache_admit_func_ptr)(struct admissioner*, const request_t *);
+typedef bool (*cache_admit_func_ptr)(struct admissioner *, const request_t *);
 typedef void (*admissioner_free_func_ptr)(struct admissioner *);
 
 typedef struct admissioner {
@@ -23,17 +23,19 @@ typedef struct admissioner {
 admissioner_t *create_bloomfilter_admissioner(const char *init_params);
 admissioner_t *create_prob_admissioner(const char *init_params);
 admissioner_t *create_size_admissioner(const char *init_params);
+admissioner_t *create_size_probabilistic_admissioner(const char *init_params);
 admissioner_t *create_adaptsize_admissioner(const char *init_params);
 
-static inline admissioner_t *create_admissioner(const char *admission_algo,
-                                                const char *admission_params) {
+static inline admissioner_t *create_admissioner(const char *admission_algo, const char *admission_params) {
   admissioner_t *admissioner = NULL;
   if (strcasecmp(admission_algo, "bloomfilter") == 0 || strcasecmp(admission_algo, "bloom-filter") == 0) {
     admissioner = create_bloomfilter_admissioner(admission_params);
-  } else if (strcasecmp(admission_algo, "prob") == 0) {
+  } else if (strcasecmp(admission_algo, "prob") == 0 || strcasecmp(admission_algo, "probabilistic") == 0) {
     admissioner = create_prob_admissioner(admission_params);
   } else if (strcasecmp(admission_algo, "size") == 0) {
     admissioner = create_size_admissioner(admission_params);
+  } else if (strcasecmp(admission_algo, "sizeProbabilistic") == 0 || strcasecmp(admission_algo, "sizeProb") == 0) {
+    admissioner = create_size_probabilistic_admissioner(admission_params);
   } else if (strcasecmp(admission_algo, "adaptsize") == 0) {
     admissioner = create_adaptsize_admissioner(admission_params);
   } else {


### PR DESCRIPTION
add size_probabilistic admission algorithm, which admits object with probability e^(-exponent * obj_size)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new admission policy and wires it into the admission factory/build, which can change cache behavior when selected and depends on parameter parsing/randomness being correct.
> 
> **Overview**
> Adds a new `sizeProbabilistic` admission algorithm that admits objects with probability `exp(-exponent * obj_size)`, including parsing an `exponent` parameter (default `1e-6`) and standard `clone`/`free` lifecycle handling.
> 
> Wires the new algorithm into the build (`CMakeLists.txt`) and the public admission factory (`create_admissioner`), including new aliases (`probabilistic`, `sizeProb`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c87482b0e7261f0fec9c8ff095bb793c7c83e6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->