### PR TITLE
Add per-request cost support (obj_cost) and cost-miss reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Run the example traces using the LRU eviction algorithm and a 1 GB cache size.
 ./bin/cachesim ../data/trace.vscsi vscsi lru 1000,16000 --ignore-obj-size 1
 
 # use a csv trace, note the quotation marks when you have multiple options
-./bin/cachesim ../data/trace.csv csv lru 1gb -t "time-col=2, obj-id-col=5, obj-size-col=4"
+./bin/cachesim ../data/trace.csv csv lru 1gb -t "time-col=2, obj-id-col=5, obj-size-col=4, obj-cost-col=6"
 
 # use a csv trace with more options
 ./bin/cachesim ../data/trace.csv csv lru 1gb -t "time-col=2, obj-id-col=5, obj-size-col=4, delimiter=,, has-header=true"
@@ -189,7 +189,7 @@ You can plot miss ratios of different algorithms and sizes, and plot the miss ra
 ```bash
 # plot miss ratio over size
 cd scripts
-python3 plot_mrc_size.py --tracepath ../data/twitter_cluster52.csv --trace-format csv --trace-format-params="time-col=1,obj-id-col=2,obj-size-col=3,delimiter=," --algos=fifo,lru,lecar,s3fifo --sizes=0.001,0.002,0.005,0.01,0.02,0.05,0.1,0.2,0.3,0.4
+python3 plot_mrc_size.py --tracepath ../data/twitter_cluster52.csv --trace-format csv --trace-format-params="time-col=1,obj-id-col=2,obj-size-col=3,obj-cost-col=4,delimiter=," --algos=fifo,lru,lecar,s3fifo --sizes=0.001,0.002,0.005,0.01,0.02,0.05,0.1,0.2,0.3,0.4
 
 # plot miss ratio over time
 python3 plot_mrc_time.py --tracepath ../data/twitter_cluster52.csv --trace-format csv --trace-format-params="time-col=1, obj-id-col=2, obj-size-col=3, delimiter=,," --algos=fifo,lru,lecar,s3fifo --report-interval=30 --miss-ratio-type="accu"

--- a/libCacheSim/bin/cachesim/sim.c
+++ b/libCacheSim/bin/cachesim/sim.c
@@ -25,6 +25,7 @@ void simulate(reader_t *reader, cache_t *cache, int report_interval,
   uint64_t req_cnt = 0, miss_cnt = 0;
   uint64_t last_req_cnt = 0, last_miss_cnt = 0;
   uint64_t req_byte = 0, miss_byte = 0;
+  double req_cost = 0, miss_cost = 0;
 
   read_one_req(reader, req);
   uint64_t start_ts = (uint64_t)req->clock_time;
@@ -52,9 +53,11 @@ void simulate(reader_t *reader, cache_t *cache, int report_interval,
 
     req_cnt++;
     req_byte += req->obj_size;
+    req_cost += req->obj_cost;
     if (cache->get(cache, req) == false) {
       miss_cnt++;
       miss_byte += req->obj_size;
+      miss_cost += req->obj_cost;
     }
     if (req->clock_time - last_report_ts >= (uint64_t)report_interval &&
         req->clock_time != 0) {
@@ -78,24 +81,28 @@ void simulate(reader_t *reader, cache_t *cache, int report_interval,
 
   char output_str[1024];
   char size_str[64];
+  double byte_miss_ratio = req_byte > 0 ? (double)miss_byte / (double)req_byte : 0.0;
+  double cost_miss_ratio = req_cost > 0 ? miss_cost / req_cost : 0.0;
 
   if (!ignore_obj_size) convert_size_to_str(cache->cache_size, size_str, 64);
 #pragma GCC diagnostic push
   // Removed unknown pragma warning
   if (!ignore_obj_size) {
     snprintf(output_str, 1024,
-             "%s %s cache size %8s, %16lu req, miss ratio %.4lf, throughput "
+             "%s %s cache size %8s, %16lu req, miss ratio %.4lf, byte miss ratio %.4lf, cost miss ratio %.4lf, throughput "
              "%.2lf MQPS\n",
              reader->trace_path, detailed_cache_name, size_str,
              (unsigned long)req_cnt, (double)miss_cnt / (double)req_cnt,
+             byte_miss_ratio, cost_miss_ratio,
              (double)req_cnt / 1000000.0 / runtime);
   } else {
     snprintf(output_str, 1024,
-             "%s %s cache size %8lld, %16lu req, miss ratio %.4lf, throughput "
+             "%s %s cache size %8lld, %16lu req, miss ratio %.4lf, byte miss ratio %.4lf, cost miss ratio %.4lf, throughput "
              "%.2lf MQPS\n",
              reader->trace_path, detailed_cache_name,
              (long long)cache->cache_size, (unsigned long)req_cnt,
              (double)miss_cnt / (double)req_cnt,
+             byte_miss_ratio, cost_miss_ratio,
              (double)req_cnt / 1000000.0 / runtime);
   }
 

--- a/libCacheSim/bin/cli_reader_utils.c
+++ b/libCacheSim/bin/cli_reader_utils.c
@@ -119,6 +119,10 @@ void parse_reader_params(const char *reader_params_str,
                strcasecmp(key, "size-col") == 0) {
       params->obj_size_field = (int)strtol(value, &end, 0);
       _check_parsed_result(end, params->obj_size_field);
+    } else if (strcasecmp(key, "obj-cost-col") == 0 ||
+               strcasecmp(key, "cost-col") == 0) {
+      params->obj_cost_field = (int)strtol(value, &end, 0);
+      _check_parsed_result(end, params->obj_cost_field);
     } else if (strcasecmp(key, "cnt-col") == 0) {
       params->cnt_field = (int)strtol(value, &end, 0);
     } else if (strcasecmp(key, "op-col") == 0) {

--- a/libCacheSim/include/libCacheSim/reader.h
+++ b/libCacheSim/include/libCacheSim/reader.h
@@ -45,6 +45,7 @@ typedef struct {
   int32_t time_field;
   int32_t obj_id_field;
   int32_t obj_size_field;
+  int32_t obj_cost_field;
   int32_t op_field;
   int32_t ttl_field;
   int32_t cnt_field;

--- a/libCacheSim/include/libCacheSim/request.h
+++ b/libCacheSim/include/libCacheSim/request.h
@@ -32,6 +32,8 @@ typedef struct request {
 
   int64_t obj_size;
 
+  int64_t obj_cost;
+
   int32_t ttl;
 
   req_op_e op;
@@ -79,6 +81,7 @@ static inline request_t *new_request(void) {
   request_t *req = my_malloc(request_t);
   memset(req, 0, sizeof(request_t));
   req->obj_size = 1;
+  req->obj_cost = 1;
   req->op = OP_NOP;
   req->valid = true;
   req->obj_id = 0;
@@ -118,14 +121,16 @@ static inline void free_request(request_t *req) { my_free(request_t, req); }
 static inline void print_request(const request_t *req) {
 #ifdef SUPPORT_TTL
   LOGGING(DEBUG_LEVEL,
-          "req clock_time %lu, id %llu, size %ld, ttl %ld, op %s, valid %d\n",
+          "req clock_time %lu, id %llu, size %ld, cost %ld, ttl %ld, op %s, valid %d\n",
           (unsigned long)req->clock_time, (unsigned long long)req->obj_id,
-          (long)req->obj_size, (long)req->ttl, req_op_str[req->op], req->valid);
+          (long)req->obj_size, (long)req->obj_cost, (long)req->ttl,
+          req_op_str[req->op], req->valid);
 #else
   LOGGING(DEBUG_LEVEL,
-          "req clock_time %lu, id %llu, size %ld, op %s, valid %d\n",
+          "req clock_time %lu, id %llu, size %ld, cost %ld, op %s, valid %d\n",
           (unsigned long)req->clock_time, (unsigned long long)req->obj_id,
-          (long)req->obj_size, req_op_str[req->op], req->valid);
+          (long)req->obj_size, (long)req->obj_cost, req_op_str[req->op],
+          req->valid);
 #endif
 }
 

--- a/libCacheSim/traceReader/generalReader/binary.c
+++ b/libCacheSim/traceReader/generalReader/binary.c
@@ -80,6 +80,15 @@ int binaryReader_setup(reader_t *const reader) {
     params->obj_size_offset = -1;
   }
 
+  params->obj_cost_field_idx = reader->init_params.obj_cost_field;
+  if (params->obj_cost_field_idx > 0) {
+    params->obj_cost_format = fmt_str[params->obj_cost_field_idx - 1];
+    params->obj_cost_offset = cal_offset(fmt_str, params->obj_cost_field_idx);
+  } else {
+    params->obj_cost_format = '\0';
+    params->obj_cost_offset = -1;
+  }
+
   params->op_field_idx = reader->init_params.op_field;
   if (params->op_field_idx > 0) {
     params->op_format = fmt_str[params->op_field_idx - 1];
@@ -147,6 +156,12 @@ int binaryReader_setup(reader_t *const reader) {
                   params->obj_size_field_idx,
                   format_to_size(params->obj_size_format),
                   params->obj_size_offset);
+  }
+  if (params->obj_cost_field_idx > 0) {
+    n += snprintf(output + n, 1024 - n, ", obj_cost_field %d,%d,%d",
+                  params->obj_cost_field_idx,
+                  format_to_size(params->obj_cost_format),
+                  params->obj_cost_offset);
   }
   if (params->op_field_idx > 0) {
     n += snprintf(output + n, 1024 - n, ", op_field %d,%d,%d",
@@ -224,6 +239,12 @@ int binary_read_one_req(reader_t *reader, request_t *req) {
   if (params->obj_size_field_idx > 0) {
     req->obj_size =
         read_data(start + params->obj_size_offset, params->obj_size_format);
+  }
+
+  /* read object cost */
+  if (params->obj_cost_field_idx > 0) {
+    req->obj_cost =
+        read_data(start + params->obj_cost_offset, params->obj_cost_format);
   }
 
   /* read operation */

--- a/libCacheSim/traceReader/generalReader/csv.c
+++ b/libCacheSim/traceReader/generalReader/csv.c
@@ -237,6 +237,11 @@ static inline void csv_cb1(void *s, size_t len, void *data) {
     if (req->obj_size == 0 && end == s) {
       WARN("csvReader obj_size is not a number: \"%s\"\n", (char *)s);
     }
+  } else if (csv_params->curr_field_idx == csv_params->obj_cost_field_idx) {
+    req->obj_cost = (int64_t)strtoll((char *)s, &end, 0);
+    if (req->obj_cost == 0 && end == s) {
+      WARN("csvReader obj_cost is not a number: \"%s\"\n", (char *)s);
+    }
   } else if (csv_params->curr_field_idx == csv_params->op_field_idx) {
     if (strncasecmp((char *)s, "read", len) == 0) {
       req->op = OP_READ;
@@ -298,6 +303,7 @@ void csv_setup_reader(reader_t *const reader) {
   csv_params->time_field_idx = init_params->time_field;
   csv_params->obj_id_field_idx = init_params->obj_id_field;
   csv_params->obj_size_field_idx = init_params->obj_size_field;
+  csv_params->obj_cost_field_idx = init_params->obj_cost_field;
   csv_params->op_field_idx = init_params->op_field;
   csv_params->ttl_field_idx = init_params->ttl_field;
   csv_params->cnt_field_idx = init_params->cnt_field;

--- a/libCacheSim/traceReader/reader.c
+++ b/libCacheSim/traceReader/reader.c
@@ -258,6 +258,8 @@ int read_one_req(reader_t *const reader, request_t *const req) {
     reader->n_read_req += 1;
     req->hv = 0;
     req->ttl = 0;
+    req->obj_size = 1;
+    req->obj_cost = 1;
     req->valid = true;
 
     switch (reader->trace_type) {
@@ -333,8 +335,13 @@ int read_one_req(reader_t *const reader, request_t *const req) {
     req->obj_size = 1;
   }
 
-  VERBOSE("read one req: time %lu, obj_id %lu, size %lu at offset %zu\n",
-          req->clock_time, req->obj_id, req->obj_size, offset_before_read);
+  if (reader->init_params.obj_cost_field <= 0) {
+    req->obj_cost = req->obj_size;
+  }
+
+  VERBOSE("read one req: time %lu, obj_id %lu, size %lu, cost %lu at offset %zu\n",
+          req->clock_time, req->obj_id, req->obj_size, req->obj_cost,
+          offset_before_read);
 
   return status;
 }

--- a/libCacheSim/traceReader/readerInternal.h
+++ b/libCacheSim/traceReader/readerInternal.h
@@ -25,6 +25,7 @@ typedef struct {
   int time_field_idx;
   int obj_id_field_idx;
   int obj_size_field_idx;
+  int obj_cost_field_idx;
   int op_field_idx;
   int cnt_field_idx;
   int ttl_field_idx;
@@ -108,6 +109,10 @@ typedef struct {
   int32_t obj_size_offset;
   int8_t obj_size_field_idx;
   char obj_size_format;
+
+  int32_t obj_cost_offset;
+  int8_t obj_cost_field_idx;
+  char obj_cost_format;
 
   int32_t n_fields;
   int32_t item_size;


### PR DESCRIPTION
### Motivation
- Provide first-class per-request "cost" in traces so simulations can report cost-weighted miss ratios in addition to object counts and bytes.
- Allow traces to carry a dedicated cost column (CSV/binary) without breaking existing traces that only supply object size.

### Description
- Added `obj_cost` to `request_t` with default initialization to `1` and included cost in `print_request` debug output.
- Extended `reader_init_param_t` with `obj_cost_field` and added parsing of `obj-cost-col` / `cost-col` in `parse_reader_params` to configure a cost column from CSV parameters.
- CSV and binary readers now parse an optional cost field (`obj_cost`) when present and wire the cost-field index/offset through `readerInternal` structures; when not configured the reader sets `req->obj_cost = req->obj_size` as a backward-compatible fallback.
- `read_one_req` initializes `obj_cost` and ensures `ignore_obj_size` behavior still applies; verbose logging now prints `size` and `cost` for each read request.
- `cachesim` simulation logic collects `req_cost` and `miss_cost`, computes `cost_miss_ratio`, and prints it alongside request miss ratio and byte miss ratio in the output.
- Updated `README.md` examples and plotting script invocation to demonstrate `obj-cost-col` usage.

### Testing
- Attempted an automated CMake configuration (`cmake -S . -B build`) which failed due to a missing system dependency `glib-2.0`, so no full build/test ran in this environment (failure is environmental, not code-related).
- No unit or integration tests were executed in the workspace; changes were validated via static edits and local file diffs and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5fd1ae0648322933f8f9c1bc3e1df)