### PR TITLE
ci: add CodeQL workflow for C/C++ analysis (#243)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (cpp)
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: cpp
+          config: |
+            paths-ignore:
+              - libCacheSim-node
+
+      - name: Install build dependencies
+        run: bash scripts/install_dependency.sh
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:cpp"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  # Match .github/workflows/build.yml (plain Release; no LSan — avoids sanitizer/CodeQL interaction)
+  BUILD_TYPE: Release
+
 jobs:
   analyze:
     name: Analyze (cpp)
@@ -26,6 +30,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: cpp
+          build-mode: manual
           config: |
             paths-ignore:
               - libCacheSim-node
@@ -33,8 +38,11 @@ jobs:
       - name: Install build dependencies
         run: bash scripts/install_dependency.sh
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+      - name: Configure CMake
+        run: cmake -G Ninja -B "${{ github.workspace }}/build" -DCMAKE_BUILD_TYPE="${{ env.BUILD_TYPE }}"
+
+      - name: Build
+        run: ninja -C "${{ github.workspace }}/build"
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## What
Add a GitHub Actions workflow for CodeQL static analysis at `.github/workflows/codeql-analysis.yml`.

## Why
Issue #243 requests enabling SAST with CodeQL so results are visible in the Security tab and in PR checks.

## Changes
- Add CodeQL workflow triggered on:
  - `push`
  - `pull_request`
- Configure CodeQL language as `cpp` (covers C/C++).
- Set required permissions for SARIF upload:
  - `contents: read`
  - `security-events: write`
- Exclude non-core path from scanning:
  - `libCacheSim-node`
- Use manual build mode for better reliability with this CMake/Ninja project:
  - install deps via `scripts/install_dependency.sh`
  - `cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Release`
  - `ninja -C build`
- Keep workflow minimal with concurrency control to avoid duplicate in-flight runs.

## Validation
- Confirm workflow is detected in Actions.
- Confirm CodeQL check appears on PR.
- Confirm code scanning results are uploaded to the Security tab.

Closes #243