### PR TITLE
fix: avoid inexact UINT64_MAX to double conversion in mrcProfiler

### DIFF
--- a/libCacheSim/mrcProfiler/mrcProfiler.cpp
+++ b/libCacheSim/mrcProfiler/mrcProfiler.cpp
@@ -15,6 +15,12 @@
 #include "../dataStructure/splaytree.hpp"
 #include "libCacheSim/const.h"
 
+/* the number of distinct 64-bit hash values (2^64), used to convert between
+ * hash values and sampling rates. UINT64_MAX itself cannot be represented
+ * exactly as a double, so using it in floating point arithmetic silently
+ * rounds to this value and warns under -Wimplicit-const-int-float-conversion */
+static constexpr double kHashSpaceSize = 18446744073709551616.0;
+
 mrcProfiler::MRCProfilerBase *mrcProfiler::create_mrc_profiler(
     mrc_profiler_e type, reader_t *reader, std::string output_path,
     const mrc_profiler_params_t &params) {
@@ -95,10 +101,13 @@ void mrcProfiler::MRCProfilerSHARDS::fixed_sample_rate_run() {
   double sample_rate = params_.shards_params.sample_rate;
   std::vector<double> local_hit_cnt_vec(mrc_size_vec.size(), 0);
   std::vector<double> local_hit_size_vec(mrc_size_vec.size(), 0);
-  uint64_t sample_max = UINT64_MAX * sample_rate;
-  if (sample_rate == 1) {
+  uint64_t sample_max;
+  if (sample_rate >= 1) {
     INFO("sample_rate is 1, no need to sample\n");
     sample_max = UINT64_MAX;
+  } else {
+    /* the product is exact and stays below 2^64 because sample_rate < 1 */
+    sample_max = static_cast<uint64_t>(kHashSpaceSize * sample_rate);
   }
   double sampled_cnt = 0, sampled_size = 0;
   int64_t current_time = 0;
@@ -213,7 +222,7 @@ void mrcProfiler::MRCProfilerSHARDS::fixed_sample_size_run() {
         sample_rate = 1.0;  // still 100% sample rate
       } else {
         sample_rate = min_value_map.get_max_value() * 1.0 /
-                      UINT64_MAX;  // adjust the sample rate
+                      kHashSpaceSize;  // adjust the sample rate
       }
 
       sampled_cnt += 1.0 / sample_rate;

--- a/libCacheSim/mrcProfiler/mrcProfiler.cpp
+++ b/libCacheSim/mrcProfiler/mrcProfiler.cpp
@@ -106,7 +106,8 @@ void mrcProfiler::MRCProfilerSHARDS::fixed_sample_rate_run() {
     INFO("sample_rate is 1, no need to sample\n");
     sample_max = UINT64_MAX;
   } else {
-    /* the product is exact and stays below 2^64 because sample_rate < 1 */
+    /* parse_params restricts sample_rate to (0, 1], so the product here is
+     * exact and stays below 2^64 */
     sample_max = static_cast<uint64_t>(kHashSpaceSize * sample_rate);
   }
   double sampled_cnt = 0, sampled_size = 0;

--- a/libCacheSim/mrcProfiler/mrcProfiler.h
+++ b/libCacheSim/mrcProfiler/mrcProfiler.h
@@ -90,7 +90,8 @@ typedef struct profiler_params {
               }
             } else {
               sample_rate = atof(buffer);
-              if (sample_rate <= 0 || sample_rate > 1) {
+              /* negated form so that NaN is rejected as well */
+              if (!(sample_rate > 0 && sample_rate <= 1)) {
                 ERROR("invalid sample rate for shards: %s\n", str);
                 exit(1);
               }
@@ -155,7 +156,8 @@ typedef struct profiler_params {
           } else if (current_param_idx == 1) {
             // check the sample rate or sample size
             sample_rate = atof(buffer);
-            if (sample_rate <= 0 || sample_rate > 1) {
+            /* negated form so that NaN is rejected as well */
+            if (!(sample_rate > 0 && sample_rate <= 1)) {
               ERROR("invalid sample rate for minisim: %s\n", str);
               exit(1);
             }


### PR DESCRIPTION
## Problem

The `build` workflow's **macos / clang** job has been failing on every push to `develop` (runs [31652310317](https://github.com/1a1a11a/libCacheSim/actions/runs/31652310317), [31650192522](https://github.com/1a1a11a/libCacheSim/actions/runs/31650192522), [31648760746](https://github.com/1a1a11a/libCacheSim/actions/runs/31648760746)). It never reaches the test step — compilation aborts:

```
libCacheSim/mrcProfiler/mrcProfiler.cpp:98:25: error: implicit conversion from
'unsigned long long' to 'double' changes value from 18446744073709551615 to
18446744073709551616 [-Werror,-Wimplicit-const-int-float-conversion]
   98 |   uint64_t sample_max = UINT64_MAX * sample_rate;

libCacheSim/mrcProfiler/mrcProfiler.cpp:216:23: error: implicit conversion from
'unsigned long long' to 'double' changes value from 18446744073709551615 to
18446744073709551616 [-Werror,-Wimplicit-const-int-float-conversion]
  215 |         sample_rate = min_value_map.get_max_value() * 1.0 /
  216 |                       UINT64_MAX;  // adjust the sample rate
```

`UINT64_MAX` (2^64 − 1) has no exact `double` representation, so both expressions were already silently computing with 2^64. The project builds with `-Wall -Wextra -Werror`, and clang diagnoses this while gcc does not — which is why only the macOS job breaks.

## Changes

- Added a file-local `kHashSpaceSize = 18446744073709551616.0` (2^64) constant and used it for both hash-value ↔ sample-rate conversions. This is exactly the value the compiler was already substituting, so the arithmetic is bit-for-bit unchanged — the rounding is now intentional rather than implicit.
- Compute `sample_max` only on the sampling path. Previously `UINT64_MAX * sample_rate` was evaluated even when `sample_rate == 1`, where the 2^64 result falls outside the `uint64_t` range and the conversion is undefined behavior; the value was then immediately overwritten with `UINT64_MAX` anyway. The guard is now `sample_rate >= 1`, equivalent for valid input since `parse_params` already rejects anything outside `(0, 1]`.

Scoped to the CI failure — no behavior change intended.

## Verification

Reproduced the failure locally with clang 18 (the warning is not macOS-specific), then confirmed the fix:

- **Full tree builds warning-free** with `clang`/`clang++` under `-Werror` (`ninja -k 0`, all 177 targets, no errors or warnings). `UINT64_MAX` is used elsewhere in the codebase, but this file held the only implicit float conversions — `histogram.c:82` already casts explicitly.
- **All 9 ctest tests pass** (`ctest -C Release --output-on-failure --parallel`).
- **Output is byte-identical before and after.** Built the unpatched code with the warning suppressed via a compiler wrapper, ran `mrcProfiler` over `data/cloudPhysicsIO.vscsi` across five configurations covering both changed code paths — `FIX_RATE,0.01` / `FIX_RATE,0.5` / `FIX_RATE,1` (line 98) and `FIX_SIZE,2048` / `FIX_SIZE,64` (line 216) — and diffed against the patched build. No differences.

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZabdGLUb3EKfynGd2NLQr)_