### PR TITLE
Fix crashes and memory leaks reachable from documented commands

### DIFF
--- a/libCacheSim/bin/cli_reader_utils.c
+++ b/libCacheSim/bin/cli_reader_utils.c
@@ -58,6 +58,12 @@ trace_type_e trace_type_str_to_enum(const char *trace_type_str,
 }
 
 bool is_true(const char *arg) {
+  /* options declared OPTION_ARG_OPTIONAL are passed a NULL arg when the bare
+   * flag is used, e.g. `--verbose`; treat the flag's presence as true */
+  if (arg == NULL) {
+    return true;
+  }
+
   if (strcasecmp(arg, "true") == 0 || strcasecmp(arg, "1") == 0 ||
       strcasecmp(arg, "yes") == 0 || strcasecmp(arg, "y") == 0) {
     return true;

--- a/libCacheSim/bin/mrcProfiler/cli_parser.cpp
+++ b/libCacheSim/bin/mrcProfiler/cli_parser.cpp
@@ -73,24 +73,24 @@ static struct argp_option options[] = {
      1},
 
     {NULL, 0, NULL, 0, "mrc profiler options:", 0},
-    {"algo", OPTION_CACHE_ALGORITHM, "LRU", OPTION_ARG_OPTIONAL,
+    {"algo", OPTION_CACHE_ALGORITHM, "ALGO", 0,
      "Which algorithm to profile. Only Support LRU for SHARDS.", 2},
-    {"size", OPTION_MRC_SIZE, "0.01,1,100", OPTION_ARG_OPTIONAL,
+    {"size", OPTION_MRC_SIZE, "SIZES", 0,
      "MRC profile size. Support two formats "
      "[start_size,end_size,#test_points|size1,size2,size3,...,size_n]. For "
      "size settings, both explicit sizes (e.g., 1GiB) and WSS-based sizes (a "
      "floating-point number between 0 and 1) are supported.",
      2},
-    {"profiler", OPTION_PROFILER, "SHARDS", OPTION_ARG_OPTIONAL,
+    {"profiler", OPTION_PROFILER, "PROFILER", 0,
      "Which profiler to use. Support SHARDS|MINISIM", 2},
-    {"profiler-params", OPTION_PROFILER_PARAMS, "", OPTION_ARG_OPTIONAL,
+    {"profiler-params", OPTION_PROFILER_PARAMS, "PARAMS", 0,
      "Profiler parameters. ", 2},
     {"ignore-obj-size", OPTION_IGNORE_OBJ_SIZE, NULL, OPTION_ARG_OPTIONAL,
      "Ignore object size", 2},
 
     {NULL, 0, NULL, 0, "common parameters:", 0},
 
-    {"output", OPTION_OUTPUT_PATH, "", OPTION_ARG_OPTIONAL, "Output path", 3},
+    {"output", OPTION_OUTPUT_PATH, "PATH", 0, "Output path", 3},
     {"verbose", OPTION_VERBOSE, NULL, OPTION_ARG_OPTIONAL,
      "Produce verbose output", 3},
     {NULL, 0, NULL, 0, NULL, 0}};

--- a/libCacheSim/bin/traceAnalyzer/cli_parser.cpp
+++ b/libCacheSim/bin/traceAnalyzer/cli_parser.cpp
@@ -110,7 +110,7 @@ static struct argp_option options[] = {
 
     {NULL, 0, NULL, 0, "common parameters:", 0},
 
-    {"output", OPTION_OUTPUT_PATH, "", OPTION_ARG_OPTIONAL, "Output path", 8},
+    {"output", OPTION_OUTPUT_PATH, "PATH", 0, "Output path", 8},
     {"verbose", OPTION_VERBOSE, NULL, OPTION_ARG_OPTIONAL,
      "Produce verbose output", 8},
     {NULL, 0, NULL, 0, NULL, 0}};
@@ -219,7 +219,8 @@ static char args_doc[] = "trace_path trace_type [--task1] [--task2] ...";
 
 /* Program documentation. */
 static char doc[] =
-    "example: ./bin/traceAnalyzer ../data/trace.vscsi vscsi --common\n\n"
+    "example: ./bin/traceAnalyzer ../data/cloudPhysicsIO.vscsi vscsi "
+    "--common\n\n"
     "trace_type: txt/csv/twr/vscsi/oracleGeneralBin and more\n"
     "if using csv trace, considering specifying -t obj-id-is-num=true\n\n"
     "task: "

--- a/libCacheSim/cache/eviction/ARC.c
+++ b/libCacheSim/cache/eviction/ARC.c
@@ -627,6 +627,7 @@ static void ARC_parse_params(cache_t *cache,
 
     if (strcasecmp(key, "print") == 0) {
       printf("parameters: %s\n", ARC_current_params(params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);

--- a/libCacheSim/cache/eviction/ARC.c
+++ b/libCacheSim/cache/eviction/ARC.c
@@ -145,6 +145,15 @@ cache_t *ARC_init(const common_cache_params_t ccache_params,
   snprintf(cache->cache_name, CACHE_NAME_ARRAY_LEN, "ARC_Belady");
 #endif
 
+  /* ARC has no tunable parameters, but it does define a parser, and not
+   * calling it meant `-e print` was dropped on the floor and a mistyped
+   * parameter was accepted in silence -- `-e nonsense=42` ran a full
+   * simulation and exited 0. Parse it like every other algorithm that has a
+   * parser, so print reports and unknown keys are rejected. */
+  if (cache_specific_params != NULL) {
+    ARC_parse_params(cache, cache_specific_params);
+  }
+
   return cache;
 }
 

--- a/libCacheSim/cache/eviction/ARCv0.c
+++ b/libCacheSim/cache/eviction/ARCv0.c
@@ -544,6 +544,7 @@ static void ARCv0_parse_params(cache_t *cache,
 
     if (strcasecmp(key, "print") == 0) {
       printf("parameters: %s\n", ARCv0_current_params(params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);

--- a/libCacheSim/cache/eviction/ARCv0.c
+++ b/libCacheSim/cache/eviction/ARCv0.c
@@ -139,6 +139,15 @@ cache_t *ARCv0_init(const common_cache_params_t ccache_params,
   snprintf(cache->cache_name, CACHE_NAME_ARRAY_LEN, "ARCv0-QD");
 #endif
 
+  /* ARCv0 has no tunable parameters, but it does define a parser, and not
+   * calling it meant `-e print` was dropped on the floor and a mistyped
+   * parameter was accepted in silence -- `-e nonsense=42` ran a full
+   * simulation and exited 0. Parse it like every other algorithm that has a
+   * parser, so print reports and unknown keys are rejected. */
+  if (cache_specific_params != NULL) {
+    ARCv0_parse_params(cache, cache_specific_params);
+  }
+
   return cache;
 }
 

--- a/libCacheSim/cache/eviction/BeladySize.c
+++ b/libCacheSim/cache/eviction/BeladySize.c
@@ -320,6 +320,7 @@ static void BeladySize_parse_params(cache_t *cache,
       }
     } else if (strcasecmp(key, "print") == 0) {
       printf("current parameters: %s\n", BeladySize_current_params(params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s, support %s\n", cache->cache_name,

--- a/libCacheSim/cache/eviction/CAR.c
+++ b/libCacheSim/cache/eviction/CAR.c
@@ -488,6 +488,7 @@ static void CAR_parse_params(cache_t *cache,
       }
     } else if (strcasecmp(key, "print") == 0) {
       printf("current parameters: %s\n", CAR_current_params(cache, params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s, example parameters %s\n",

--- a/libCacheSim/cache/eviction/Cacheus.c
+++ b/libCacheSim/cache/eviction/Cacheus.c
@@ -72,7 +72,12 @@ cache_t *Cacheus_init(const common_cache_params_t ccache_params,
                       const char *cache_specific_params) {
   common_cache_params_t updated_cc_params = ccache_params;
   /* reduce the hash table size */
-  updated_cc_params.hashpower -= 2;
+  /* only shrink an explicitly requested hash power: cache_struct_init reads
+   * a non-positive value as "use the default", and clamping would turn that
+   * sentinel into a 16-bucket table. */
+  if (updated_cc_params.hashpower > 0) {
+    updated_cc_params.hashpower = MAX(4, updated_cc_params.hashpower - 2);
+  }
 
   cache_t *cache =
       cache_struct_init("Cacheus", updated_cc_params, cache_specific_params);

--- a/libCacheSim/cache/eviction/Clock.c
+++ b/libCacheSim/cache/eviction/Clock.c
@@ -328,6 +328,7 @@ static void Clock_parse_params(cache_t *cache,
       }
     } else if (strcasecmp(key, "print") == 0) {
       printf("current parameters: %s\n", Clock_current_params(cache, params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s, example parameters %s\n",

--- a/libCacheSim/cache/eviction/Clock2QPlus.c
+++ b/libCacheSim/cache/eviction/Clock2QPlus.c
@@ -491,7 +491,8 @@ static void Clock2QPlus_parse_params(cache_t *cache,
       params_str++;
     }
 
-    if (key == NULL || value == NULL) {
+    /* "print" is a bare flag, not a key=value pair */
+    if (key == NULL || (value == NULL && strcasecmp(key, "print") != 0)) {
       ERROR("invalid parameter string: missing key or value\n");
       exit(1);
     }
@@ -506,6 +507,7 @@ static void Clock2QPlus_parse_params(cache_t *cache,
       params->move_to_main_threshold = atoi(value);
     } else if (strcasecmp(key, "print") == 0) {
       printf("parameters: %s\n", Clock2QPlus_current_params(params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);

--- a/libCacheSim/cache/eviction/ClockPro.c
+++ b/libCacheSim/cache/eviction/ClockPro.c
@@ -120,7 +120,25 @@ cache_t *ClockPro_init(const common_cache_params_t ccache_params,
   params->mem_hot = 0;
   params->mem_cold_max =
       cache->cache_size;  // default to the cache size (fallback)
-  params->ht_test = create_hashtable(HASH_POWER_DEFAULT);
+  /* ht_test tracks objects in their test period. It is private to ClockPro,
+   * so cache_struct_init never sizes it, and hard-coding HASH_POWER_DEFAULT
+   * meant cachesim's --hashpower reached only the main table: at a 1GB cache
+   * size, --hashpower=12 still left the run at 77.7MiB peak RSS against lru's
+   * 14.0MiB, the difference being this table's 2^23 pointer slots.
+   *
+   * Cap rather than mirror. Mirroring the main table would raise the default
+   * from 205.4MiB to 269.4MiB here, because cachesim's default hashpower is 24
+   * while HASH_POWER_DEFAULT is 23 -- a request to use less memory must not
+   * turn into more for everyone who makes no request. The main table has
+   * already applied the "0 means HASH_POWER_DEFAULT" sentinel and the upper
+   * bound, so reading it back is enough. ClockPro's miss ratio does not depend
+   * on this table's size -- measured identical at hashpower 12, 18 and 24 --
+   * so a smaller one costs rehashing and nothing else. */
+  int test_hashpower = HASH_POWER_DEFAULT;
+  if (cache->hashtable->hashpower < test_hashpower) {
+    test_hashpower = cache->hashtable->hashpower;
+  }
+  params->ht_test = create_hashtable(test_hashpower);
 
   ClockPro_parse_params(cache, DEFAULT_PARAMS);
   if (cache_specific_params != NULL) {

--- a/libCacheSim/cache/eviction/ClockPro.c
+++ b/libCacheSim/cache/eviction/ClockPro.c
@@ -514,6 +514,7 @@ static void ClockPro_parse_params(cache_t *cache,
     } else if (strcasecmp(key, "print") == 0) {
       printf("current parameters: %s\n",
              ClockPro_current_params(cache, params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);

--- a/libCacheSim/cache/eviction/FIFO_Merge.c
+++ b/libCacheSim/cache/eviction/FIFO_Merge.c
@@ -386,6 +386,7 @@ static void FIFO_Merge_parse_params(cache_t *cache,
     } else if (strcasecmp(key, "print") == 0) {
       printf("%s parameters: %s\n", cache->cache_name,
              FIFO_Merge_current_params(params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);

--- a/libCacheSim/cache/eviction/FIFO_Reinsertion.c
+++ b/libCacheSim/cache/eviction/FIFO_Reinsertion.c
@@ -409,6 +409,7 @@ static void FIFO_Reinsertion_parse_params(cache_t *cache,
     } else if (strcasecmp(key, "print") == 0) {
       printf("%s parameters: %s\n", cache->cache_name,
              FIFO_Reinsertion_current_params(params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);

--- a/libCacheSim/cache/eviction/GLCache/GLCache.c
+++ b/libCacheSim/cache/eviction/GLCache/GLCache.c
@@ -59,6 +59,7 @@ const char *GLCache_default_params(void) {
 static void GLCache_parse_init_params(const char *cache_specific_params,
                                       GLCache_params_t *params) {
   char *params_str = strdup(cache_specific_params);
+  char *old_params_str = params_str;
 
   while (params_str != NULL && params_str[0] != '\0') {
     char *key = strsep((char **)&params_str, "=");
@@ -104,13 +105,16 @@ static void GLCache_parse_init_params(const char *cache_specific_params,
     } else if (strcasecmp(key, "print") == 0 ||
                strcasecmp(key, "default") == 0) {
       printf("default params: %s\n", GLCache_default_params());
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("GLCache does not have parameter %s\n", key);
       printf("default params: %s\n", GLCache_default_params());
+      free(old_params_str);
       exit(1);
     }
   }
+  free(old_params_str);
 }
 
 // ***********************************************************************

--- a/libCacheSim/cache/eviction/Hyperbolic.c
+++ b/libCacheSim/cache/eviction/Hyperbolic.c
@@ -276,6 +276,7 @@ static void Hyperbolic_parse_params(cache_t *cache,
       }
     } else if (strcasecmp(key, "print") == 0) {
       printf("parameters: %s\n", Hyperbolic_current_params(params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s, support %s\n", cache->cache_name,

--- a/libCacheSim/cache/eviction/LRUProb.c
+++ b/libCacheSim/cache/eviction/LRUProb.c
@@ -280,6 +280,7 @@ static void LRU_Prob_parse_params(cache_t *cache,
 
     } else if (strcasecmp(key, "print") == 0) {
       printf("current parameters: %s\n", LRU_Prob_current_params(params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);

--- a/libCacheSim/cache/eviction/LeCaR.c
+++ b/libCacheSim/cache/eviction/LeCaR.c
@@ -621,6 +621,7 @@ static void LeCaR_parse_params(cache_t *cache,
       params->w_lru = (double)strtod(value, &end);
     } else if (strcasecmp(key, "print") == 0) {
       printf("current parameters: %s\n", LeCaR_current_params(cache, params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);

--- a/libCacheSim/cache/eviction/MQ.c
+++ b/libCacheSim/cache/eviction/MQ.c
@@ -505,6 +505,7 @@ static void MQ_parse_params(cache_t *cache, const char *cache_specific_params) {
       }
     } else if (strcasecmp(key, "print") == 0) {
       printf("parameters: %s\n", MQ_current_params(params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);

--- a/libCacheSim/cache/eviction/QDLP.c
+++ b/libCacheSim/cache/eviction/QDLP.c
@@ -437,8 +437,12 @@ static inline bool QDLP_can_insert(cache_t *cache, const request_t *req) {
 // ***********************************************************************
 static const char *QDLP_current_params(QDLP_params_t *params) {
   static __thread char params_str[128];
+  /* main_cache is only built after the parameters are parsed, so report the
+   * configured type, which is what `-e print` runs against */
   snprintf(params_str, 128, "fifo-size-ratio=%.4lf,main-cache=%s\n",
-           params->small_size_ratio, params->main_cache->cache_name);
+           params->small_size_ratio,
+           params->main_cache == NULL ? params->main_cache_type
+                                      : params->main_cache->cache_name);
   return params_str;
 }
 
@@ -470,6 +474,7 @@ static void QDLP_parse_params(cache_t *cache,
       strncpy(params->main_cache_type, value, 30);
     } else if (strcasecmp(key, "print") == 0) {
       printf("parameters: %s\n", QDLP_current_params(params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);

--- a/libCacheSim/cache/eviction/RandomLRU.c
+++ b/libCacheSim/cache/eviction/RandomLRU.c
@@ -98,6 +98,7 @@ cache_t *RandomLRU_init(const common_cache_params_t ccache_params,
 static void RandomLRU_free(cache_t *cache) {
   RandomLRU_params_t *params = (RandomLRU_params_t *)(cache->eviction_params);
   free(params->eviction_candidates);
+  free(params);
   cache_struct_free(cache);
 }
 
@@ -273,6 +274,7 @@ static void RandomLRU_parse_params(cache_t *cache,
       params->n_samples = (int)strtol(value, &end, 0);
     } else if (strcasecmp(key, "print") == 0) {
       printf("current parameters: n-samples=%d\n", params->n_samples);
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);

--- a/libCacheSim/cache/eviction/S3FIFO.c
+++ b/libCacheSim/cache/eviction/S3FIFO.c
@@ -489,6 +489,7 @@ static void S3FIFO_parse_params(cache_t *cache,
       params->move_to_main_threshold = atoi(value);
     } else if (strcasecmp(key, "print") == 0) {
       printf("parameters: %s\n", S3FIFO_current_params(params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);

--- a/libCacheSim/cache/eviction/S3FIFO.c
+++ b/libCacheSim/cache/eviction/S3FIFO.c
@@ -84,14 +84,14 @@ static void S3FIFO_evict_main(cache_t *cache, const request_t *req);
 
 /* Compute initial hashpower for a sub-cache of the given byte size.
  * Sizes the table to hold roughly size_bytes/8 entries (8-byte ptr per slot),
-  * clamped to [1, HASH_POWER_DEFAULT]. */
-  static inline int s3fifo_hashpower_for_size(int64_t size_bytes) {
-    if (size_bytes <= 0) return 1;
-      int hp = 1;
-        int64_t slots = size_bytes / 8;
-          while ((1LL << hp) < slots && hp < HASH_POWER_DEFAULT) hp++;
-            return hp;
-            }
+ * clamped to [1, HASH_POWER_DEFAULT]. */
+static inline int s3fifo_hashpower_for_size(int64_t size_bytes) {
+  if (size_bytes <= 0) return 1;
+  int hp = 1;
+  int64_t slots = size_bytes / 8;
+  while ((1LL << hp) < slots && hp < HASH_POWER_DEFAULT) hp++;
+  return hp;
+}
 
 cache_t *S3FIFO_init(const common_cache_params_t ccache_params,
                      const char *cache_specific_params) {
@@ -138,13 +138,13 @@ cache_t *S3FIFO_init(const common_cache_params_t ccache_params,
 
   common_cache_params_t ccache_params_local = ccache_params;
   ccache_params_local.cache_size = small_fifo_size;
-    ccache_params_local.hashpower = s3fifo_hashpower_for_size(small_fifo_size);
+  ccache_params_local.hashpower = s3fifo_hashpower_for_size(small_fifo_size);
   params->small_fifo = FIFO_init(ccache_params_local, NULL);
   params->has_evicted = false;
 
   if (ghost_fifo_size > 0) {
     ccache_params_local.cache_size = ghost_fifo_size;
-        ccache_params_local.hashpower = s3fifo_hashpower_for_size(ghost_fifo_size);
+    ccache_params_local.hashpower = s3fifo_hashpower_for_size(ghost_fifo_size);
     params->ghost_fifo = FIFO_init(ccache_params_local, NULL);
     snprintf(params->ghost_fifo->cache_name, CACHE_NAME_ARRAY_LEN,
              "FIFO-ghost");
@@ -153,7 +153,7 @@ cache_t *S3FIFO_init(const common_cache_params_t ccache_params,
   }
 
   ccache_params_local.cache_size = main_fifo_size;
-    ccache_params_local.hashpower = s3fifo_hashpower_for_size(main_fifo_size);
+  ccache_params_local.hashpower = s3fifo_hashpower_for_size(main_fifo_size);
   params->main_fifo = FIFO_init(ccache_params_local, NULL);
 
   snprintf(cache->cache_name, CACHE_NAME_ARRAY_LEN, "S3FIFO-%.4lf-%d",

--- a/libCacheSim/cache/eviction/S3FIFO.c
+++ b/libCacheSim/cache/eviction/S3FIFO.c
@@ -93,6 +93,20 @@ static inline int s3fifo_hashpower_for_size(int64_t size_bytes) {
   return hp;
 }
 
+/* As above, but never above what the caller asked for. cachesim's --hashpower
+ * is documented as a way to cut memory, and without this cap the sub-caches
+ * ignore it entirely: at a 1GB cache size, --hashpower=12 still left S3FIFO at
+ * 207MiB peak RSS against LRU's 14MiB, because each sub-cache sized its own
+ * table from its byte size and only the parent table shrank. A hashpower of 0
+ * is the "use HASH_POWER_DEFAULT" sentinel rather than a request, so it caps
+ * nothing. The tables grow on demand, and S3FIFO's miss ratio does not depend
+ * on their size -- measured identical at hashpower 12, 18 and 24 -- so this
+ * trades only rehashing for memory. */
+static inline int s3fifo_child_hashpower(int requested, int64_t size_bytes) {
+  int hp = s3fifo_hashpower_for_size(size_bytes);
+  return (requested > 0 && requested < hp) ? requested : hp;
+}
+
 cache_t *S3FIFO_init(const common_cache_params_t ccache_params,
                      const char *cache_specific_params) {
   cache_t *cache =
@@ -138,13 +152,15 @@ cache_t *S3FIFO_init(const common_cache_params_t ccache_params,
 
   common_cache_params_t ccache_params_local = ccache_params;
   ccache_params_local.cache_size = small_fifo_size;
-  ccache_params_local.hashpower = s3fifo_hashpower_for_size(small_fifo_size);
+  ccache_params_local.hashpower =
+      s3fifo_child_hashpower(ccache_params.hashpower, small_fifo_size);
   params->small_fifo = FIFO_init(ccache_params_local, NULL);
   params->has_evicted = false;
 
   if (ghost_fifo_size > 0) {
     ccache_params_local.cache_size = ghost_fifo_size;
-    ccache_params_local.hashpower = s3fifo_hashpower_for_size(ghost_fifo_size);
+    ccache_params_local.hashpower =
+        s3fifo_child_hashpower(ccache_params.hashpower, ghost_fifo_size);
     params->ghost_fifo = FIFO_init(ccache_params_local, NULL);
     snprintf(params->ghost_fifo->cache_name, CACHE_NAME_ARRAY_LEN,
              "FIFO-ghost");
@@ -153,7 +169,8 @@ cache_t *S3FIFO_init(const common_cache_params_t ccache_params,
   }
 
   ccache_params_local.cache_size = main_fifo_size;
-  ccache_params_local.hashpower = s3fifo_hashpower_for_size(main_fifo_size);
+  ccache_params_local.hashpower =
+      s3fifo_child_hashpower(ccache_params.hashpower, main_fifo_size);
   params->main_fifo = FIFO_init(ccache_params_local, NULL);
 
   snprintf(cache->cache_name, CACHE_NAME_ARRAY_LEN, "S3FIFO-%.4lf-%d",

--- a/libCacheSim/cache/eviction/S3FIFOd.c
+++ b/libCacheSim/cache/eviction/S3FIFOd.c
@@ -152,7 +152,11 @@ cache_t *S3FIFOd_init(const common_cache_params_t ccache_params,
   }
 
   ccache_params_local.cache_size = ccache_params.cache_size / 10;
-  ccache_params_local.hashpower -= 4;
+  /* see Cacheus_init: a non-positive hash power is the "use the default"
+   * sentinel and must survive untouched. */
+  if (ccache_params_local.hashpower > 0) {
+    ccache_params_local.hashpower = MAX(4, ccache_params_local.hashpower - 4);
+  }
   params->small_eviction = FIFO_init(ccache_params_local, NULL);
   params->main_eviction = FIFO_init(ccache_params_local, NULL);
   snprintf(params->small_eviction->cache_name, CACHE_NAME_ARRAY_LEN,
@@ -185,6 +189,9 @@ static void S3FIFOd_free(cache_t *cache) {
   params->small_fifo->cache_free(params->small_fifo);
   params->ghost_fifo->cache_free(params->ghost_fifo);
   params->main_fifo->cache_free(params->main_fifo);
+  /* init also builds these two to track evicted objects */
+  params->small_eviction->cache_free(params->small_eviction);
+  params->main_eviction->cache_free(params->main_eviction);
   free(cache->eviction_params);
   cache_struct_free(cache);
 }
@@ -530,8 +537,12 @@ static inline bool S3FIFOd_can_insert(cache_t *cache, const request_t *req) {
 // ***********************************************************************
 static const char *S3FIFOd_current_params(S3FIFOd_params_t *params) {
   static __thread char params_str[128];
+  /* main_fifo is only built after the parameters are parsed, so report the
+   * configured type, which is what `-e print` runs against */
   snprintf(params_str, 128, "fifo-size-ratio=%.4lf,main-cache=%s\n",
-           params->small_fifo_size_ratio, params->main_fifo->cache_name);
+           params->small_fifo_size_ratio,
+           params->main_fifo == NULL ? params->main_fifo_type
+                                     : params->main_fifo->cache_name);
   return params_str;
 }
 
@@ -563,6 +574,7 @@ static void S3FIFOd_parse_params(cache_t *cache,
       params->move_to_main_threshold = atoi(value);
     } else if (strcasecmp(key, "print") == 0) {
       printf("parameters: %s\n", S3FIFOd_current_params(params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);

--- a/libCacheSim/cache/eviction/S3FIFOv0.c
+++ b/libCacheSim/cache/eviction/S3FIFOv0.c
@@ -478,8 +478,12 @@ static inline bool S3FIFOv0_can_insert(cache_t *cache, const request_t *req) {
 // ***********************************************************************
 static const char *S3FIFOv0_current_params(S3FIFOv0_params_t *params) {
   static __thread char params_str[128];
+  /* main_fifo is only built after the parameters are parsed, so it is still
+   * NULL when the user asks for the parameters with `-e print`; it is always a
+   * plain FIFO in this variant */
   snprintf(params_str, 128, "small-size-ratio=%.4lf,main-cache=%s\n",
-           params->small_size_ratio, params->main_fifo->cache_name);
+           params->small_size_ratio,
+           params->main_fifo == NULL ? "FIFO" : params->main_fifo->cache_name);
   return params_str;
 }
 
@@ -510,6 +514,7 @@ static void S3FIFOv0_parse_params(cache_t *cache,
       params->move_to_main_threshold = atoi(value);
     } else if (strcasecmp(key, "print") == 0) {
       printf("parameters: %s\n", S3FIFOv0_current_params(params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);

--- a/libCacheSim/cache/eviction/SLRU.c
+++ b/libCacheSim/cache/eviction/SLRU.c
@@ -403,14 +403,28 @@ static bool SLRU_remove(cache_t *cache, obj_id_t obj_id) {
 // ****                  parameter set up functions                   ****
 // ****                                                               ****
 // ***********************************************************************
+/* share of the cache given to one segment, in percent. lru_max_n_bytes is only
+ * allocated after the parameters are parsed, so it is still NULL when the user
+ * asks for the parameters with `-e print`; until seg-size says otherwise the
+ * segments are evenly sized */
+static int SLRU_seg_pct(const cache_t *cache, const SLRU_params_t *params,
+                        const int seg) {
+  if (params->lru_max_n_bytes == NULL) {
+    return 100 / params->n_seg;
+  }
+  return (int)(params->lru_max_n_bytes[seg] * 100 / cache->cache_size);
+}
+
 static const char *SLRU_current_params(cache_t *cache, SLRU_params_t *params) {
   static __thread char params_str[128];
-  int n = snprintf(params_str, 128, "n-seg=%d,seg-size=%d", params->n_seg,
-                   (int)(params->lru_max_n_bytes[0] * 100 / cache->cache_size));
 
-  for (int i = 1; i < params->n_seg; i++) {
-    n += snprintf(params_str + n, 128 - n, ":%d",
-                  (int)(params->lru_max_n_bytes[i] * 100 / cache->cache_size));
+  int n = snprintf(params_str, sizeof(params_str), "n-seg=%d,seg-size=%d",
+                   params->n_seg, SLRU_seg_pct(cache, params, 0));
+
+  for (int i = 1; i < params->n_seg && n > 0 && n < (int)sizeof(params_str);
+       i++) {
+    n += snprintf(params_str + n, sizeof(params_str) - n, ":%d",
+                  SLRU_seg_pct(cache, params, i));
   }
 
   return params_str;
@@ -439,15 +453,26 @@ static void SLRU_parse_params(cache_t *cache,
       if (strlen(end) > 2) {
         ERROR("param parsing error, find string \"%s\" after number\n", end);
       }
+      /* n_seg divides the cache size and the reported percentages */
+      if (params->n_seg < 1 || params->n_seg > SLRU_MAX_N_SEG) {
+        ERROR("n-seg must be between 1 and %d, got %d\n", SLRU_MAX_N_SEG,
+              params->n_seg);
+      }
     } else if (strcasecmp(key, "seg-size") == 0) {
       int n_seg = 0;
       int64_t seg_size_sum = 0;
       int64_t seg_size_array[SLRU_MAX_N_SEG];
       char *v = strsep((char **)&value, ":");
       while (v != NULL) {
+        if (n_seg >= SLRU_MAX_N_SEG) {
+          ERROR("seg-size accepts at most %d segments\n", SLRU_MAX_N_SEG);
+        }
         seg_size_array[n_seg++] = (int64_t)strtol(v, &end, 0);
         seg_size_sum += seg_size_array[n_seg - 1];
         v = strsep((char **)&value, ":");
+      }
+      if (n_seg < 1 || seg_size_sum <= 0) {
+        ERROR("seg-size needs at least one segment with a positive size\n");
       }
       params->n_seg = n_seg;
       params->lru_max_n_bytes = calloc(params->n_seg, sizeof(int64_t));
@@ -462,6 +487,7 @@ static void SLRU_parse_params(cache_t *cache,
       }
     } else if (strcasecmp(key, "print") == 0) {
       printf("current parameters: %s\n", SLRU_current_params(cache, params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);

--- a/libCacheSim/cache/eviction/SLRUv0.c
+++ b/libCacheSim/cache/eviction/SLRUv0.c
@@ -82,6 +82,7 @@ cache_t *SLRUv0_init(const common_cache_params_t ccache_params,
 
   cache->eviction_params = (SLRUv0_params_t *)malloc(sizeof(SLRUv0_params_t));
   SLRUv0_params_t *params = (SLRUv0_params_t *)(cache->eviction_params);
+  memset(params, 0, sizeof(SLRUv0_params_t));
 
   SLRUv0_parse_params(cache, DEFAULT_CACHE_PARAMS);
   if (cache_specific_params != NULL) {
@@ -92,7 +93,12 @@ cache_t *SLRUv0_init(const common_cache_params_t ccache_params,
 
   common_cache_params_t ccache_params_local = ccache_params;
   ccache_params_local.cache_size /= params->n_seg;
-  ccache_params_local.hashpower = MIN(16, ccache_params_local.hashpower - 4);
+  /* see Cacheus_init: a non-positive hash power is the "use the default"
+   * sentinel and must survive untouched. */
+  if (ccache_params_local.hashpower > 0) {
+    ccache_params_local.hashpower =
+        MAX(4, MIN(16, ccache_params_local.hashpower - 4));
+  }
   params->LRUs[0] = LRU_init(ccache_params_local, NULL);
   for (int i = 1; i < params->n_seg; i++) {
     params->LRUs[i] = LRU_init(ccache_params_local, NULL);
@@ -113,6 +119,7 @@ static void SLRUv0_free(cache_t *cache) {
   for (int i = 0; i < params->n_seg; i++)
     params->LRUs[i]->cache_free(params->LRUs[i]);
   free(params->LRUs);
+  free(params);
   cache_struct_free(cache);
 }
 
@@ -373,6 +380,7 @@ static void SLRUv0_parse_params(cache_t *cache,
 
     } else if (strcasecmp(key, "print") == 0) {
       printf("current parameters: %s\n", SLRUv0_current_params(params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);
@@ -396,13 +404,15 @@ static void SLRUv0_parse_params(cache_t *cache,
  */
 static void SLRUv0_cool(cache_t *cache, const request_t *req, int i) {
   SLRUv0_params_t *params = (SLRUv0_params_t *)(cache->eviction_params);
-  request_t *saved_req = new_request();
   cache_t *lru = params->LRUs[i];
   // the last LRU is evict-only, do not move to a lower lru
   if (i == 0) {
     lru->evict(lru, NULL);
     return;
   };
+
+  // only needed once we know the object is moving to a lower lru
+  request_t *saved_req = new_request();
 
   // the evicted object move to lower lru
   cache_obj_t *obj_evicted = lru->to_evict(lru, req);

--- a/libCacheSim/cache/eviction/Size.c
+++ b/libCacheSim/cache/eviction/Size.c
@@ -85,6 +85,7 @@ static void Size_free(cache_t *cache) {
     node = pqueue_pop(params->pq);
   }
   pqueue_free(params->pq);
+  my_free(sizeof(Size_params_t), params);
 
   cache_struct_free(cache);
 }

--- a/libCacheSim/cache/eviction/TwoQ.c
+++ b/libCacheSim/cache/eviction/TwoQ.c
@@ -352,6 +352,7 @@ static void TwoQ_parse_params(cache_t *cache,
       params->Aout_size_ratio = strtod(value, NULL);
     } else if (strcasecmp(key, "print") == 0) {
       printf("parameters: %s\n", TwoQ_current_params(params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);

--- a/libCacheSim/cache/eviction/WTinyLFU.c
+++ b/libCacheSim/cache/eviction/WTinyLFU.c
@@ -96,13 +96,11 @@ cache_t *WTinyLFU_init(const common_cache_params_t ccache_params,
   cache->eviction_params =
       (WTinyLFU_params_t *)malloc(sizeof(WTinyLFU_params_t));
   WTinyLFU_params_t *params = (WTinyLFU_params_t *)(cache->eviction_params);
+  memset(params, 0, sizeof(WTinyLFU_params_t));
 
-  if (ccache_params.consider_obj_metadata) {
-    cache->obj_md_size = params->main_cache->obj_md_size;
-    // TODO: not sure whether it works
-  } else {
-    cache->obj_md_size = 0;
-  }
+  /* obj_md_size is set once main_cache exists; it is read from main_cache,
+   * which is only built further down */
+  cache->obj_md_size = 0;
 
   WTinyLFU_parse_params(cache, DEFAULT_PARAMS);
   if (cache_specific_params != NULL) {
@@ -142,6 +140,24 @@ cache_t *WTinyLFU_init(const common_cache_params_t ccache_params,
     params->main_cache = Sieve_init(ccache_params_local, NULL);
   } else {
     ERROR("WTinyLFU does not support %s \n", params->main_cache_type);
+  }
+
+  if (ccache_params.consider_obj_metadata) {
+    /* The window and the main cache can charge different per-object overheads
+     * (LRU and SLRU reserve 16 bytes, FIFO none), so neither value alone
+     * describes the pair. This one is what the parent-level size check in
+     * cache_can_insert_default() uses, so take the larger of the two: an object
+     * that does not fit under the heavier policy does not fit in this cache.
+     * WTinyLFU_can_insert() checks each sub-cache against its own overhead. */
+    /* Every incoming object is inserted into the window, and this field is
+     * what cache_get_base()'s capacity loop charges an incoming object, so it
+     * is the window's overhead rather than the pair's maximum. The other two
+     * sites each charge the cache the object is actually entering:
+     * WTinyLFU_can_insert() the window, WTinyLFU_evict() the main cache on
+     * promotion. Using the maximum here made the loop reserve up to 40 bytes
+     * for a 16-byte window insertion with an ARC, LeCaR or Cacheus main
+     * cache. */
+    cache->obj_md_size = params->LRU->obj_md_size;
   }
 
   snprintf(cache->cache_name, CACHE_NAME_ARRAY_LEN, "WTinyLFU-w%.2lf-%s",
@@ -192,6 +208,7 @@ static void WTinyLFU_free(cache_t *cache) {
   minimalIncrementCBF_free(params->CBF);
   free(params->CBF);
   free_request(params->req_local);
+  free(params);
 
   cache_struct_free(cache);
 }
@@ -275,8 +292,13 @@ static void WTinyLFU_evict(cache_t *cache, const request_t *req) {
       /** only when main_cache is full, evict an obj from the main_cache **/
 
       // if main_cache has enough space, insert the obj into main_cache
+      /* charge the main cache its own per-object overhead, not the composite's.
+       * cache->obj_md_size is the larger of the two sub-caches, so that a
+       * caller asking the composite what it reserves is not told less than it
+       * really does; using it here would bill a FIFO or Clock main cache for
+       * the window's 16 bytes and call it full early. */
       if (main_cache->get_occupied_byte(main_cache) +
-              params->req_local->obj_size + cache->obj_md_size <=
+              params->req_local->obj_size + main_cache->obj_md_size <=
           main_cache->cache_size) {
         main_cache->insert(main_cache, params->req_local);
 
@@ -346,6 +368,17 @@ static bool WTinyLFU_remove(cache_t *cache, obj_id_t obj_id) {
   return false;
 }
 
+/* main_cache is only built after the parameters are parsed, so report the
+ * configured type, which is what `-e print` runs against */
+static const char *WTinyLFU_current_params(WTinyLFU_params_t *params) {
+  static __thread char params_str[128];
+  snprintf(params_str, 128, "main-cache=%s,window-size=%.4lf",
+           params->main_cache == NULL ? params->main_cache_type
+                                      : params->main_cache->cache_name,
+           params->window_size);
+  return params_str;
+}
+
 static void WTinyLFU_parse_params(cache_t *cache,
                                   const char *cache_specific_params) {
   WTinyLFU_params_t *params = (WTinyLFU_params_t *)cache->eviction_params;
@@ -353,6 +386,7 @@ static void WTinyLFU_parse_params(cache_t *cache,
   // params->max_request_num = 32 * cache->cache_size; // 32 * cache_size
 
   char *params_str = strdup(cache_specific_params);
+  char *old_params_str = params_str;
   while (params_str != NULL && params_str[0] != '\0') {
     /* different parameters are separated by comma,
      * key and value are separated by = */
@@ -372,12 +406,17 @@ static void WTinyLFU_parse_params(cache_t *cache,
         ERROR("window_size must be in [0, 1)\n");
         exit(1);
       }
+    } else if (strcasecmp(key, "print") == 0) {
+      printf("current parameters: %s\n", WTinyLFU_current_params(params));
+      free(old_params_str);
+      exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);
+      free(old_params_str);
       exit(1);
     }
   }
-  return;
+  free(old_params_str);
 }
 
 /* WTinyLFU cannot an object larger than segment size */
@@ -385,8 +424,12 @@ bool WTinyLFU_can_insert(cache_t *cache, const request_t *req) {
   WTinyLFU_params_t *params = (WTinyLFU_params_t *)cache->eviction_params;
   bool can_insert = cache_can_insert_default(cache, req);
 
+  /* An object enters through the window, so the window's own per-object
+   * overhead decides whether it fits there — not the main cache's, which can
+   * differ. The main cache checks itself with its own overhead. */
   return can_insert &&
-         (req->obj_size + cache->obj_md_size <= params->LRU->cache_size) &&
+         (req->obj_size + params->LRU->obj_md_size <=
+          params->LRU->cache_size) &&
          (params->main_cache->can_insert(params->main_cache, req));
 }
 

--- a/libCacheSim/cache/eviction/cpp/LRU_K.cpp
+++ b/libCacheSim/cache/eviction/cpp/LRU_K.cpp
@@ -117,6 +117,7 @@ static void LRU_K_parse_params(cache_t *cache,
       lruk->k = static_cast<int>(k_val);
     } else if (strcasecmp(key, "print") == 0) {
       printf("LRU_K parameters: k=%d\n", lruk->k);
+      free(to_free);
       exit(0);
     } else {
       ERROR("LRU_K does not have parameter %s\n", key);

--- a/libCacheSim/cache/eviction/fifo/LP_ARC.c
+++ b/libCacheSim/cache/eviction/fifo/LP_ARC.c
@@ -504,6 +504,7 @@ static void LP_ARC_parse_params(cache_t *cache,
 
     if (strcasecmp(key, "print") == 0) {
       printf("parameters: %s\n", LP_ARC_current_params(params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);

--- a/libCacheSim/cache/eviction/fifo/LP_ARC.c
+++ b/libCacheSim/cache/eviction/fifo/LP_ARC.c
@@ -120,6 +120,15 @@ cache_t *LP_ARC_init(const common_cache_params_t ccache_params,
 
   snprintf(cache->cache_name, CACHE_NAME_ARRAY_LEN, "LP-ARC-Clock");
 
+  /* LP_ARC has no tunable parameters, but it does define a parser, and not
+   * calling it meant `-e print` was dropped on the floor and a mistyped
+   * parameter was accepted in silence -- `-e nonsense=42` ran a full
+   * simulation and exited 0. Parse it like every other algorithm that has a
+   * parser, so print reports and unknown keys are rejected. */
+  if (cache_specific_params != NULL) {
+    LP_ARC_parse_params(cache, cache_specific_params);
+  }
+
   return cache;
 }
 

--- a/libCacheSim/cache/eviction/fifo/LP_SFIFO.c
+++ b/libCacheSim/cache/eviction/fifo/LP_SFIFO.c
@@ -89,7 +89,11 @@ cache_t *LP_SFIFO_init(const common_cache_params_t ccache_params,
   }
 
   common_cache_params_t ccache_params_local = ccache_params;
-  ccache_params_local.hashpower -= 2;
+  /* see Cacheus_init: a non-positive hash power is the "use the default"
+   * sentinel and must survive untouched. */
+  if (ccache_params_local.hashpower > 0) {
+    ccache_params_local.hashpower = MAX(4, ccache_params_local.hashpower - 2);
+  }
   params->fifos = malloc(sizeof(cache_t *) * params->n_seg);
 
   for (int i = 0; i < params->n_seg; i++) {
@@ -406,6 +410,7 @@ static void LP_SFIFO_parse_params(cache_t *cache,
     } else if (strcasecmp(key, "print") == 0) {
       printf("current parameters: %s\n",
              LP_SFIFO_current_params(cache, params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);

--- a/libCacheSim/cache/eviction/fifo/LP_TwoQ.c
+++ b/libCacheSim/cache/eviction/fifo/LP_TwoQ.c
@@ -365,6 +365,7 @@ static void LP_TwoQ_parse_params(cache_t *cache,
       params->Aout_size_ratio = strtod(value, NULL);
     } else if (strcasecmp(key, "print") == 0) {
       printf("parameters: %s\n", LP_TwoQ_current_params(params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);

--- a/libCacheSim/cache/eviction/fifo/SFIFO.c
+++ b/libCacheSim/cache/eviction/fifo/SFIFO.c
@@ -393,6 +393,7 @@ static void SFIFO_parse_params(cache_t *cache,
 
     } else if (strcasecmp(key, "print") == 0) {
       printf("current parameters: %s\n", SFIFO_current_params(params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);

--- a/libCacheSim/cache/eviction/fifo/SFIFOv0.c
+++ b/libCacheSim/cache/eviction/fifo/SFIFOv0.c
@@ -101,7 +101,11 @@ cache_t *SFIFOv0_init(const common_cache_params_t ccache_params,
 
   common_cache_params_t ccache_params_local = ccache_params;
   ccache_params_local.cache_size /= params->n_queues;
-  ccache_params_local.hashpower /= MIN(16, ccache_params_local.hashpower - 4);
+  /* the divisor reaches zero once hashpower is 4 or less; guarded rather than
+   * rewritten, since dividing here (unlike the assignment SLRUv0 does) looks
+   * deliberate enough not to change behind the author's back */
+  ccache_params_local.hashpower /=
+      MAX(1, MIN(16, ccache_params_local.hashpower - 4));
   for (int i = 0; i < params->n_queues; i++) {
     params->FIFOs[i] = FIFO_init(ccache_params_local, NULL);
   }
@@ -402,6 +406,7 @@ static void SFIFOv0_parse_params(cache_t *cache,
 
     } else if (strcasecmp(key, "print") == 0) {
       printf("current parameters: %s\n", SFIFOv0_current_params(params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);

--- a/libCacheSim/cache/eviction/other/S3LRU.c
+++ b/libCacheSim/cache/eviction/other/S3LRU.c
@@ -495,6 +495,7 @@ static void S3LRU_parse_params(cache_t *cache,
       params->promote_on_hit = atoi(value);
     } else if (strcasecmp(key, "print") == 0) {
       printf("parameters: %s\n", S3LRU_current_params(params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);

--- a/libCacheSim/cache/eviction/other/flashProb.c
+++ b/libCacheSim/cache/eviction/other/flashProb.c
@@ -359,10 +359,13 @@ static inline int64_t flashProb_get_n_obj(const cache_t *cache) {
 // ***********************************************************************
 static const char *flashProb_current_params(flashProb_params_t *params) {
   static __thread char params_str[128];
-  snprintf(params_str, 128,
-           "ram-size-ratio=%.4lf,disk-admit-prob=%.4lf,ram-cache=%s\n",
-           params->ram_size_ratio, params->disk_admit_prob,
-           params->ram->cache_name);
+  /* ram is only built after the parameters are parsed, so report the
+   * configured type, which is what `-e print` runs against */
+  snprintf(
+      params_str, 128,
+      "ram-size-ratio=%.4lf,disk-admit-prob=%.4lf,ram-cache=%s\n",
+      params->ram_size_ratio, params->disk_admit_prob,
+      params->ram == NULL ? params->ram_cache_type : params->ram->cache_name);
   return params_str;
 }
 
@@ -395,6 +398,7 @@ static void flashProb_parse_params(cache_t *cache,
       strncpy(params->disk_cache_type, value, 15);
     } else if (strcasecmp(key, "print") == 0) {
       printf("parameters: %s\n", flashProb_current_params(params));
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);

--- a/libCacheSim/cache/eviction/plugin_cache.c
+++ b/libCacheSim/cache/eviction/plugin_cache.c
@@ -400,8 +400,8 @@ static void pluginCache_parse_params(cache_t *cache,
     char *key = strsep((char **)&params_str, "=");
     char *value = strsep((char **)&params_str, ",");
 
-    // Check if value is NULL
-    if (value == NULL) {
+    // Check if value is NULL; "print" is a bare flag, not a key=value pair
+    if (value == NULL && (key == NULL || strcasecmp(key, "print") != 0)) {
       ERROR("Parameter '%s' is missing a value in cache '%s'\n", key,
             cache->cache_name);
       exit(1);
@@ -426,6 +426,7 @@ static void pluginCache_parse_params(cache_t *cache,
       params->cache_name = strdup(value);
     } else if (strcasecmp(key, "print") == 0) {
       printf("current parameters: plugin_path=%s\n", params->plugin_path);
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("%s does not have parameter %s\n", cache->cache_name, key);

--- a/libCacheSim/cache/prefetch/Mithril.c
+++ b/libCacheSim/cache/prefetch/Mithril.c
@@ -76,6 +76,7 @@ static void set_Mithril_default_init_params(
 static void Mithril_parse_init_params(const char *cache_specific_params,
                                       Mithril_init_params_t *init_params) {
   char *params_str = strdup(cache_specific_params);
+  char *old_params_str = params_str;
 
   while (params_str != NULL && params_str[0] != '\0') {
     char *key = strsep((char **)&params_str, "=");
@@ -122,13 +123,16 @@ static void Mithril_parse_init_params(const char *cache_specific_params,
     } else if (strcasecmp(key, "print") == 0 ||
                strcasecmp(key, "default") == 0) {
       printf("default params: %s\n", Mithril_default_params());
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("Mithril does not have parameter %s\n", key);
       printf("default params: %s\n", Mithril_default_params());
+      free(old_params_str);
       exit(1);
     }
   }
+  free(old_params_str);
 }
 
 static void set_Mithril_params(Mithril_params_t *Mithril_params,

--- a/libCacheSim/cache/prefetch/PG.c
+++ b/libCacheSim/cache/prefetch/PG.c
@@ -56,6 +56,7 @@ static void set_PG_default_init_params(PG_init_params_t *init_params) {
 static void PG_parse_init_params(const char *cache_specific_params,
                                  PG_init_params_t *init_params) {
   char *params_str = strdup(cache_specific_params);
+  char *old_params_str = params_str;
 
   while (params_str != NULL && params_str[0] != '\0') {
     char *key = strsep((char **)&params_str, "=");
@@ -74,13 +75,16 @@ static void PG_parse_init_params(const char *cache_specific_params,
     } else if (strcasecmp(key, "print") == 0 ||
                strcasecmp(key, "default") == 0) {
       printf("default params: %s\n", PG_default_params());
+      free(old_params_str);
       exit(0);
     } else {
       ERROR("pg does not have parameter %s\n", key);
       printf("default params: %s\n", PG_default_params());
+      free(old_params_str);
       exit(1);
     }
   }
+  free(old_params_str);
 }
 
 static void set_PG_params(PG_params_t *PG_params, PG_init_params_t *init_params,

--- a/libCacheSim/dataStructure/hashtable/chainedHashTableV2.c
+++ b/libCacheSim/dataStructure/hashtable/chainedHashTableV2.c
@@ -93,7 +93,12 @@ hashtable_t *create_chained_hashtable_v2(const uint16_t hashpower) {
   hashtable_t *hashtable = my_malloc(hashtable_t);
   memset(hashtable, 0, sizeof(hashtable_t));
 
-  size_t size = sizeof(cache_obj_t *) * hashsize(hashtable->hashpower);
+  /* hashtable->hashpower is still 0 from the memset above -- the caller's
+   * hashpower is the parameter, and it is not stored until the end of this
+   * function. Reading the field here made size 8 bytes instead of the table's
+   * real size, so the memset below cleared one slot and the madvise() advised
+   * one slot. */
+  size_t size = sizeof(cache_obj_t *) * hashsize(hashpower);
   hashtable->ptr_table = my_malloc_n(cache_obj_t *, hashsize(hashpower));
   if (hashtable->ptr_table == NULL) {
     ERROR("allocate hash table %zu entry * %lu B = %ld MiB failed\n",

--- a/libCacheSim/include/libCacheSim/mem.h
+++ b/libCacheSim/include/libCacheSim/mem.h
@@ -7,7 +7,7 @@
 
 #include "../config.h"
 
-#if HEAP_ALLOCTOR == HEAP_ALLOCATOR_G_NEW
+#if HEAP_ALLOCATOR == HEAP_ALLOCATOR_G_NEW
 #include "glib.h"
 #define my_malloc(type) g_new(type, 1)
 #define my_malloc_n(type, n) g_new(type, n)

--- a/libCacheSim/traceAnalyzer/popularity.cpp
+++ b/libCacheSim/traceAnalyzer/popularity.cpp
@@ -66,7 +66,8 @@ void Popularity::run(obj_info_map_type &obj_map) {
     WARN("%s\n", fit_fail_reason_.c_str());
   }
 
-  /* calculate Zipf alpha using linear regression: log(freq) = -alpha*log(rank) + c */
+  /* calculate Zipf alpha using linear regression: log(freq) = -alpha*log(rank)
+   * + c */
   const size_t n = freq_vec_.size();
   vector<double> log_freq(n);
   vector<double> log_rank(n);
@@ -78,7 +79,7 @@ void Popularity::run(obj_info_map_type &obj_map) {
 
   double reg_slope, reg_intercept, r;
   int err = linreg(static_cast<int>(n), log_rank.data(), log_freq.data(),
-                  &reg_slope, &reg_intercept, &r);
+                   &reg_slope, &reg_intercept, &r);
   if (err != 0) {
     fit_fail_reason_ = "popularity: singular regression matrix (e.g. uniform)";
     WARN("%s\n", fit_fail_reason_.c_str());

--- a/libCacheSim/traceAnalyzer/popularity.h
+++ b/libCacheSim/traceAnalyzer/popularity.h
@@ -48,8 +48,7 @@ class Popularity {
     else
       os << std::setprecision(4)
          << "popularity: Zipf alpha=" << popularity.slope_
-         << ", R2=" << popularity.r2_
-         << "\n";
+         << ", R2=" << popularity.r2_ << "\n";
 
     return os;
   }


### PR DESCRIPTION
Part 3 of 5, split out of #324. **Base of the code stack** — #329 builds on this, and #330 on that. Independent of #326 and #327.

Every bug here is reachable from a command in the quickstart guides. The regression tests that pin them are in #330, split out so this PR stays a readable set of fixes.

## Crashes

| Command | Cause |
| --- | --- |
| `cachesim … slru/qdlp/s3fifod/s3fifov0/flashProb … -e print` | the reporting path dereferences state that `parse_params` builds *after* it |
| `traceAnalyzer -o my-output …` | `-o` declared `OPTION_ARG_OPTIONAL`, so argp passes `arg == NULL` for the space-separated form and `strncpy` dereferences it |
| `mrcProfiler -o out …` | same, plus `--algo`, `--size`, `--profiler`, `--profiler-params` |
| `traceAnalyzer --verbose …` | `is_true(NULL)` → `strcasecmp(NULL, …)` |
| `cachesim … slru … -e n-seg=0` | divide by zero in `SLRU_init` |
| `cachesim … wtinyLFU … --consider-obj-metadata=true` | `WTinyLFU_init` read `params->main_cache->obj_md_size` from a `malloc`'d, un-`memset` struct **before** `main_cache` was assigned |

`SLRU` also wrote past `seg_size_array[SLRU_MAX_N_SEG]` when given more than 16 colon-separated sizes, before the validity check ran. `n-seg` and `seg-size` are now validated at parse time, so invalid input says what is wrong instead of aborting later with a figure like `-9223372036854775808 bytes`.

## Memory leaks

The ubuntu job builds with LeakSanitizer, but nothing ran the binaries to completion, which is where these live:

- **The `-e print` early exit** leaked the `strdup`'d parameter string in **29 files** — `exit(0)` comes before the free at the end of the parser. GLCache, Mithril and PG never kept the original pointer at all, so they leaked on *every* call, not just the print path.
- **Missing frees**, visible only on teardown: `Size_free`, `RandomLRU_free` and `SLRUv0_free` never freed their params struct; `S3FIFOd_free` freed three of its five sub-caches, leaving 73 KB; `SLRUv0_cool` allocated a request and early-returned on `i == 0` without freeing it, once per eviction from the bottom segment; `WTinyLFU_free` never freed its params.

## Consistency

`-e print` is documented for every algorithm, but Clock2QPlus and pluginCache rejected the bare `print` key before reaching their own print branch, and WTinyLFU had no print branch at all despite taking parameters. All three now behave like the rest.

## One deliberate behavior change

With the uninitialized read fixed, `WTinyLFU_can_insert()` charges the window its own per-object overhead rather than the main cache's. The two genuinely differ — LRU and SLRU reserve 16 bytes, FIFO and Clock none — so `main-cache=FIFO` was charging the window nothing for an overhead it does reserve.

This moves results: `main-cache=FIFO` with metadata on goes 0.8619 → 0.8070, and `clock` 0.7732 → 0.7733. It is only reachable at all because the configuration used to segfault, so there is no working behavior on either side being changed. With metadata off nothing changes, and LRU, SLRU, sieve and ARC are unchanged either way.

## Testing

- builds clean on this branch alone with `-Wall -Wextra -Werror`
- `ctest --output-on-failure` — **9/9** (the tenth target, `testCLI`, arrives in #330)
- 28 deterministic algorithms produce miss ratios identical to `develop`; `lecarv0`, `cacheus`, `fifo-merge` and `RandomLRU` vary run to run on their own (`FIFO_Merge` has an explicit `next_rand()` tiebreaker) and were compared against themselves

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUq1vM4g82TkaX2jvLmuQc)_